### PR TITLE
#242 バックエンド側でアナウンス情報は保持させるように変更

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,17 @@ ADVERTISED_IP=127.0.0.1
 RECORDING_HTTP_ADDR=0.0.0.0:18080
 
 # Frontend サーバ URL（serversync 使用時のみ必須。main voicebot では任意）
-# 別マシン構成では Backend のアナウンス音声HTTP取得にも使用（未設定時はローカルパス変換にフォールバック）
+# 別マシン構成では serversync がアナウンス音声キャッシュ取得元として使用
 # 例: FRONTEND_BASE_URL=http://192.168.1.5:3000
 # FRONTEND_BASE_URL=http://localhost:3000
+
+# アナウンス音声キャッシュ保存先（デフォルト: data/announcements）
+# 相対パスはバックエンドプロセスの working directory 基準
+# 本番環境（systemd 等）では絶対パスを推奨
+# 例: ANNOUNCEMENT_AUDIO_DIR=/home/pi/voicebot/data/announcements
+# 例（同一マシンで frontend public を直接参照）:
+# ANNOUNCEMENT_AUDIO_DIR=/home/pi/voicebot/virtual-voicebot-frontend/public/audio/announcements
+# ANNOUNCEMENT_AUDIO_DIR=data/announcements
 
 # =============================================================================
 # === Backend — AI サービス ===

--- a/virtual-voicebot-backend/docs/steering/STEER-242_announce-audio-local-cache.md
+++ b/virtual-voicebot-backend/docs/steering/STEER-242_announce-audio-local-cache.md
@@ -1,0 +1,494 @@
+# STEER-242: アナウンス音声のローカルキャッシュ対応（フロントエンド非依存再生）
+
+---
+
+## 1. メタ情報
+
+| 項目 | 値 |
+|------|-----|
+| ID | STEER-242 |
+| タイトル | アナウンス音声のローカルキャッシュ対応（フロントエンド非依存再生） |
+| ステータス | Approved |
+| 関連Issue | #242 |
+| 優先度 | P1 |
+| 作成日 | 2026-02-24 |
+
+---
+
+## 2. ストーリー（Why）
+
+### 2.1 背景
+
+STEER-227（#227）でアナウンス音声の HTTP 取得（再生時フェッチ）を実装したが、
+この実装は **再生時点でフロントエンドが稼働している** ことを前提としている。
+
+**現状の問題:**
+
+| 問題 | 詳細 |
+|------|------|
+| 再生時 HTTP 取得 | `resolve_audio_file_url()`（`coordinator.rs` L545）は `FRONTEND_BASE_URL` が設定されている場合、着信ごとに `fetch_audio_to_temp()` を呼び出してフロントエンドから音声を取得する |
+| フロントエンド停止で再生不可 | フロントエンド PC をスリープ/停止するとリクエストが失敗し、`failed to fetch audio` となりアナウンスが再生されない |
+| ラズパイ単体運用を阻害 | フロントエンドが別 PC の場合、その PC が常時起動していなければアナウンス再生ができない |
+
+**ログ事象（Issue #242）:**
+
+```
+[session xxx] failed to fetch audio from http://<frontend-pc>:3000 err=...
+```
+
+**根本原因:**
+
+- STEER-164（#164）でアナウンス同期が実装されたが、音声ファイル本体のダウンロードは未実装のまま。
+- STEER-227（#227）は「再生時に毎回 HTTP 取得」という方式で別マシン問題を解消したが、フロントエンド依存は残存した。
+
+### 2.2 目的
+
+音声ファイルを **同期時（serversync）に Backend ローカルに保存** し、
+再生時はローカルキャッシュを直接参照することで、
+フロントエンドの稼働状態に依存しないアナウンス再生を実現する。
+
+対象は AN/VM アナウンス音声だけでなく、IVR メニュー音声・VB（Voicebot）イントロ音声も含め、
+`resolve_audio_file_url()` を共通関数として全音声に統一する（`fetch_audio_to_temp()` 全廃）。
+
+### 2.3 ユーザーストーリー
+
+```
+As a システム管理者
+I want to フロントエンド PC が停止していてもアナウンス再生したい
+So that ラズパイ単体でアナウンスが再生でき、フロントエンド PC の起動状態に依存しない安定した運用ができる
+
+受入条件:
+- [ ] AC-1: フロントエンド PC が停止中でも、既存アナウンスが再生される（AN/VM mode）
+- [ ] AC-2: serversync 実行時（フロントエンド稼働中）に音声ファイルが Backend ローカルに保存される
+- [ ] AC-3: アナウンス更新時（Frontend の updatedAt 変化）に音声ファイルが再ダウンロードされる
+- [ ] AC-4: アナウンス削除時にローカルの音声ファイルも削除される
+- [ ] AC-5: 音声ダウンロード失敗時は WARN ログが出るが、DB メタデータ同期および他アナウンスの処理は継続される
+- [ ] AC-6: ローカルキャッシュが存在しないアナウンスを再生しようとした場合、WARN ログが出てフォールバック音声が再生される
+- [ ] AC-7: フロントエンド PC が停止中でも、IVR メニュー音声・VB（Voicebot）イントロ音声が再生される
+```
+
+---
+
+## 3. 段取り（Who / When）
+
+### 3.1 起票
+
+| 項目 | 値 |
+|------|-----|
+| 起票者 | @MasanoriSuda |
+| 起票日 | 2026-02-24 |
+| 起票理由 | フロントエンド PC を停止するとアナウンス再生が失敗する（Issue #242） |
+
+### 3.2 仕様作成
+
+| 項目 | 値 |
+|------|-----|
+| 作成者 | Claude Sonnet 4.6 |
+| 作成日 | 2026-02-24 |
+| 指示者 | @MasanoriSuda |
+| 指示内容 | "#242 のステアリング作成。Codex との会話で方針確認済み：同期時に音声ファイルをラズパイに保存し、再生時はローカル参照に統一する" |
+
+### 3.3 レビュー
+
+| # | レビュアー | 日付 | 結果 | コメント |
+|---|-----------|------|------|---------|
+| 1 | Codex | 2026-02-24 | NG | 重大①`updated_at` 比較が現状実装で成立しない（DTO/保存方法の変更必要）、重大②トランザクション内でファイルI/O、重大③部分ファイル残存リスク、中①DL失敗スコープ曖昧、中②相対パス基準未定義、軽①TTS説明誤り |
+
+### 3.4 承認
+
+| 項目 | 値 |
+|------|-----|
+| 承認者 | @MasanoriSuda |
+| 承認日 | 2026-02-24 |
+| 承認コメント | lgtm |
+
+### 3.5 実装
+
+| 項目 | 値 |
+|------|-----|
+| 実装者 | Codex (GPT-5) |
+| 実装日 | 2026-02-24 |
+| 指示者 | @MasanoriSuda |
+| 指示内容 | 「STEER-242 の実装をお願いします Refs #242」 |
+| コードレビュー | 未実施（PR/CodeRabbit 待ち） |
+
+### 3.6 マージ
+
+| 項目 | 値 |
+|------|-----|
+| マージ実行者 | - |
+| マージ日 | - |
+| マージ先 | `coordinator.rs`、`handlers/mod.rs`、`converters.rs`（または新規 `audio_downloader.rs`）、`frontend_pull.rs`、`config/mod.rs`、`.env.example` |
+
+---
+
+## 4. 影響範囲
+
+### 4.1 影響するドキュメント
+
+| ドキュメント | 変更種別 | 概要 |
+|-------------|---------|------|
+| `.env.example`（ルート） | 修正 | `ANNOUNCEMENT_AUDIO_DIR` 追加。同一マシン構成での設定例および working directory 注意事項を記載 |
+
+### 4.2 影響するコード
+
+| ファイル | 変更種別 | 概要 |
+|---------|---------|------|
+| `src/interface/sync/converters.rs` | 修正 | `FrontendAnnouncement` DTO に `updated_at` フィールド追加。UPSERT で `updated_at` に Frontend 値を保存（`NOW()` から変更） |
+| `src/interface/sync/frontend_pull.rs` | 修正 | `save_snapshot()` 前にファイルダウンロードフェーズを追加（トランザクション外）。削除対象ファイルの削除もトランザクション外に移動 |
+| `src/interface/sync/audio_downloader.rs` | 新規 | 音声ファイルダウンロード・保存（tmp→rename）・削除ロジック（または `frontend_pull.rs` に内包） |
+| `src/protocol/session/coordinator.rs` | 修正 | `resolve_audio_file_url()` をローカルキャッシュ参照に変更。`fetch_audio_to_temp()` 関数・`audio_tmp_files` フィールド・`map_audio_file_url_to_local_path()` 関数を削除 |
+| `src/protocol/session/handlers/mod.rs` | 修正 | IVR メニュー音声（L998 付近）・VB（Voicebot）イントロ音声（L1278 付近）を `resolve_audio_file_url()` に統一（STEER-227 未適用箇所が残る場合のみ） |
+| `src/shared/config/mod.rs` | 修正 | `AnnouncementConfig` に `audio_dir: String` を追加（`ANNOUNCEMENT_AUDIO_DIR` 環境変数） |
+
+---
+
+## 5. 差分仕様（What / How）
+
+### 5.1 設計方針
+
+| フェーズ | 変更前（STEER-227 後） | 変更後 |
+|----------|----------------------|--------|
+| 同期時（serversync） | メタデータのみ DB 保存。`updated_at` は `NOW()` | メタデータ保存（`updated_at` = Frontend `updatedAt`）＋ トランザクション外で音声ファイルダウンロード |
+| 再生時（voicebot） | `FRONTEND_BASE_URL` + URL で HTTP GET → 一時ファイル | `ANNOUNCEMENT_AUDIO_DIR/{filename}` を直接参照（全音声種別で統一） |
+| フロントエンド依存 | 再生時に必要 | 同期時のみ（フロントエンドが停止中でも再生可能） |
+
+**ファイル名規則:**
+
+`audio_file_url` の最終セグメントをそのままファイル名として使用する。
+
+例: `/audio/announcements/dca2a704-23c6-45fe-a16a-2c059bab0e45.wav`
+→ ローカルパス: `{ANNOUNCEMENT_AUDIO_DIR}/dca2a704-23c6-45fe-a16a-2c059bab0e45.wav`
+
+DB スキーマの列追加は行わない。`audio_file_url` カラムは URL 文字列のまま保持し、再生時にファイル名を取り出してローカルパスに変換する。
+
+### 5.2 `ANNOUNCEMENT_AUDIO_DIR` の config 追加
+
+```rust
+// src/shared/config/mod.rs — AnnouncementConfig に追加
+#[derive(Clone, Debug)]
+pub struct AnnouncementConfig {
+    pub frontend_base_url: Option<String>,
+    /// アナウンス音声ファイルのローカルキャッシュディレクトリ
+    /// デフォルト: "data/announcements"
+    /// 相対パスはバックエンドプロセスの working directory 基準。
+    /// Raspberry Pi の systemd 運用では絶対パス（例: /home/pi/voicebot/data/announcements）を推奨。
+    pub audio_dir: String,
+}
+
+impl AnnouncementConfig {
+    fn from_env() -> Self {
+        Self {
+            frontend_base_url: env_non_empty("FRONTEND_BASE_URL"),
+            audio_dir: env_non_empty("ANNOUNCEMENT_AUDIO_DIR")
+                .unwrap_or_else(|| "data/announcements".to_string()),
+        }
+    }
+}
+```
+
+> **注:** `ANNOUNCEMENT_AUDIO_DIR` の相対パスはバックエンドプロセスの `cwd` 基準。
+> systemd で `WorkingDirectory` を設定する場合は、その値を基準として解決される。
+> ズレを防ぐため、本番環境では絶対パスを推奨する（`.env.example` に明記）。
+
+### 5.3 `FrontendAnnouncement` DTO と `updated_at` 保存の変更
+
+現行 `FrontendAnnouncement` 構造体（`converters.rs` L95）には `updated_at` フィールドがなく、
+DB の `updated_at` は `NOW()` で保存されている。更新検知を正しく行うために両方を変更する。
+
+#### 5.3.1 DTO への `updated_at` 追加
+
+```rust
+// src/interface/sync/converters.rs — FrontendAnnouncement に追加
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendAnnouncement {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    #[serde(default = "default_announcement_type")]
+    pub announcement_type: String,
+    #[serde(default = "default_true")]
+    pub is_active: bool,
+    pub audio_file_url: Option<String>,
+    pub tts_text: Option<String>,
+    pub duration_sec: Option<f64>,
+    // 追加: Frontend の updatedAt を取得する
+    // Option にすることで既存テストが壊れない（フィールドなしは None として扱う）
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+```
+
+#### 5.3.2 DB UPSERT での `updated_at` 変更
+
+`convert_announcements()` の INSERT/UPSERT（`converters.rs` L365 付近）で、
+`updated_at` を `NOW()` ではなく Frontend の値を使うよう変更する。
+
+```sql
+-- 変更前（NOW() 使用）:
+INSERT INTO announcements (..., updated_at)
+VALUES (..., NOW())
+ON CONFLICT (id) DO UPDATE SET ..., updated_at = NOW();
+
+-- 変更後（Frontend の updatedAt を使用）:
+INSERT INTO announcements (..., updated_at)
+VALUES (..., $updated_at)                            -- Frontend の updatedAt（None の場合は NOW()）
+ON CONFLICT (id) DO UPDATE SET ..., updated_at = EXCLUDED.updated_at;
+```
+
+> `updated_at` が `None`（古い Frontend 実装等）の場合は `chrono::Utc::now()` を fallback として使用する。
+
+### 5.4 同期時の音声ダウンロード（`frontend_pull.rs` 拡張）
+
+#### 5.4.1 処理フロー（トランザクション外/内の分離）[重大②対応]
+
+```
+serversync 実行フロー（変更後）:
+
+【Phase 1: DB トランザクション外（ファイル I/O フェーズ）】
+
+1. Frontend から announcements メタデータ（Vec<FrontendAnnouncement>）を取得
+2. 現在の DB から（id → updated_at, audio_file_url）をクエリ（SELECT のみ）
+3. 削除対象アナウンス（Frontend に存在しない ID）のローカルファイルを削除
+   - ファイルが存在しない場合は無視（エラーにしない）
+4. 各アナウンスについてダウンロード要否を判定（以下のいずれかを満たす場合）:
+   - ローカルファイルが存在しない
+   - Frontend の `updated_at` が Some であり、かつ DB の `updated_at` と異なる
+   - Frontend の `updated_at` が None の場合は `updated_at` 比較を行わず、ファイル不存在のみで判定する
+     （古い Frontend 実装との互換性確保のため。毎回再 DL は行わない）
+5. ダウンロード対象ファイルを tmp ファイルに保存 → 成功後に rename（原子的置換）
+   - DL失敗: WARN ログ＋当該ファイルのみスキップ（後続アナウンス・Phase 2 は継続）
+   - DL失敗時もメタデータ DB 同期は Phase 2 で実施する（音声キャッシュ更新のみスキップ）[中①確定]
+
+【Phase 2: DB トランザクション内（メタデータ同期フェーズ）】
+
+6. apply_frontend_snapshot() を実行（既存処理と同様）
+   - convert_announcements(): updated_at = Frontend の updatedAt を保存（§5.3 参照）
+   - number-groups, call-actions, ivr-flows: 現状と同じ
+```
+
+> **不変条件:** Phase 2（DB トランザクション内）でファイル I/O は行わない。
+> ファイル状態と DB 状態の完全な一致は保証しない（ベストエフォート）。
+> ファイルのみ更新後に DB が失敗した場合、次回 serversync で `updated_at` 比較により再 DL が行われる。
+
+#### 5.4.2 `audio_file_url = None` のスキップ条件[軽①対応]
+
+ダウンロードフェーズで `audio_file_url` が `None` のアナウンスはスキップする。
+これは音声未設定アナウンス（TTS・Upload を問わず、`audioFileUrl` が返らない状態）を表す。
+TTS 作成時でも Frontend は `audioFileUrl` を生成・保存するため、
+TTS アナウンスが `audio_file_url = None` になることは通常ない。
+
+#### 5.4.3 ダウンロード関数（原子的書き込み）[重大③対応]
+
+```rust
+// src/interface/sync/audio_downloader.rs（新規）または frontend_pull.rs 内
+async fn download_audio_file(
+    http_client: &reqwest::Client,
+    frontend_base_url: &str,
+    url_path: &str,        // 例: "/audio/announcements/xxx.wav"（バリデーション済み）
+    local_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    const MAX_BYTES: u64 = 8 * 1024 * 1024;  // STEER-227 と統一
+
+    let full_url = format!("{}{}", frontend_base_url.trim_end_matches('/'), url_path);
+    let mut resp = http_client.get(&full_url).send().await?.error_for_status()?;
+
+    // 親ディレクトリ作成
+    let parent = local_path.parent().expect("local_path has parent");
+    std::fs::create_dir_all(parent)?;
+
+    // 原子的書き込み: {filename}.tmp に書いてから rename[重大③]
+    let tmp_path = local_path.with_extension("tmp");
+    let result: anyhow::Result<()> = async {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        let mut total = 0u64;
+        while let Some(chunk) = resp.chunk().await? {
+            total = total.checked_add(chunk.len() as u64)
+                .ok_or_else(|| anyhow::anyhow!("size overflow"))?;
+            if total > MAX_BYTES {
+                return Err(anyhow::anyhow!("audio too large: {} bytes", total));
+            }
+            std::io::Write::write_all(&mut file, &chunk)?;
+        }
+        Ok(())
+    }.await;
+
+    // エラー（MAX_BYTES 超過・通信切断・timeout 等）はすべて tmp を削除[重大③]
+    if let Err(err) = result {
+        std::fs::remove_file(&tmp_path).ok();  // 削除失敗は無視
+        return Err(err);
+    }
+
+    // 成功時のみ rename（原子的置換）
+    std::fs::rename(&tmp_path, local_path)?;
+    Ok(())
+}
+```
+
+- `FRONTEND_BASE_URL` が未設定の場合は `download_audio_file()` を呼び出さない（Phase 1 全体をスキップ）。
+- タイムアウトは `http_client` の設定で管理（serversync の既存タイムアウト設定を踏襲）。
+
+### 5.5 再生時の `resolve_audio_file_url()` 変更（AN/VM 音声）
+
+```rust
+// src/protocol/session/coordinator.rs
+// シグネチャは既存の &mut self のまま（STEER-227 適用済み前提）
+async fn resolve_audio_file_url(&mut self, audio_file_url: String) -> Option<String> {
+    let cfg = config::announcement_config();
+    let url_path = extract_url_path(&audio_file_url);
+
+    if !is_safe_announcement_url_path(&url_path) {
+        log::warn!(
+            "[session {}] rejected unsafe audio url path: {}",
+            self.call_id, url_path
+        );
+        return None;
+    }
+
+    // url_path の最終セグメントからローカルパスを構築
+    let filename = url_path.rsplit('/').next()?;
+    let local_path = std::path::Path::new(&cfg.audio_dir).join(filename);
+
+    if local_path.exists() {
+        return Some(local_path.to_string_lossy().to_string());
+    }
+
+    // ローカルキャッシュが存在しない場合（sync 未実施または失敗）
+    log::warn!(
+        "[session {}] local audio cache not found: {:?} (has serversync run?)",
+        self.call_id, local_path
+    );
+    None
+    // → 呼び出し側の既存フォールバックに委ねる（AN/VM → ANNOUNCEMENT_FALLBACK_WAV_PATH 等）
+}
+```
+
+**削除対象コード（coordinator.rs）:**
+- `fetch_audio_to_temp()` 関数
+- `SessionCoordinator.audio_tmp_files: Vec<NamedTempFile>` フィールド
+- `map_audio_file_url_to_local_path()` 関数（後方互換フォールバック不要のため[Q3確定]）
+
+**変更点の概要:**
+
+| 項目 | 変更前（STEER-227） | 変更後 |
+|------|-------------------|--------|
+| `FRONTEND_BASE_URL` あり | HTTP GET → 一時ファイル | ローカルキャッシュ参照 |
+| `FRONTEND_BASE_URL` なし | `map_audio_file_url_to_local_path()`（従来パス） | ローカルキャッシュ参照（後方互換フォールバックなし） |
+| 失敗時 | WARN + None | WARN + None（同等） |
+| 一時ファイル管理 | `audio_tmp_files: Vec<NamedTempFile>` | 不要（フィールド削除） |
+
+### 5.6 IVR メニュー音声・VB（Voicebot）イントロ音声の変更（handlers/mod.rs）[Q4確定]
+
+`resolve_audio_file_url()` の内部実装変更のみで AN/VM 以外の音声も統一される。
+
+**STEER-227 適用済みの場合:** `handlers/mod.rs` のコード変更は不要。
+呼び出し先の `resolve_audio_file_url()` がローカルキャッシュを参照するよう変わるため、
+IVR/VB のフォールバック先（`IVR_INTRO_WAV_PATH` / `VOICEBOT_INTRO_WAV_PATH`）も引き続き機能する。
+
+**STEER-227 未適用箇所が残る場合:** `map_audio_file_url_to_local_path()` の直接呼び出しを
+`self.resolve_audio_file_url(url).await` に差し替えること（STEER-227 §5.5/5.6 参照）。
+
+### 5.7 `FRONTEND_BASE_URL` 未設定時の挙動
+
+| 状況 | 変更後 |
+|------|--------|
+| serversync 実行・FRONTEND_BASE_URL 未設定 | Phase 1（ファイル DL）をスキップ。メタデータのみ DB 同期 |
+| 再生時・ローカルファイルあり | 直接再生 |
+| 再生時・ローカルファイルなし | WARN ログ + フォールバック音声 |
+
+**同一マシン構成での対応方法（`.env.example` に記載）:**
+
+`map_audio_file_url_to_local_path()` は削除されるため、既存ファイルを参照したい場合は
+`ANNOUNCEMENT_AUDIO_DIR` を明示的に設定する。
+
+```dotenv
+# 同一マシン構成（音声ファイルが frontend の public/ にある場合）の例
+# 注意: 相対パスはバックエンドプロセスの working directory 基準
+# 本番環境（systemd 等）では絶対パスを推奨
+ANNOUNCEMENT_AUDIO_DIR=/home/pi/voicebot/virtual-voicebot-frontend/public/audio/announcements
+```
+
+---
+
+## 6. トレーサビリティ
+
+| From | To | 関係 |
+|------|-----|------|
+| Issue #242 | STEER-242 | 起票 |
+| STEER-164 §5.4 | STEER-242 | STEER-164 で未実装だった音声ファイル転送を本ステアリングで実現 |
+| STEER-227 | STEER-242 | STEER-227 の再生時 HTTP フェッチをローカルキャッシュに置き換え |
+| STEER-242 §5.3 | `src/interface/sync/converters.rs` | FrontendAnnouncement DTO・UPSERT 変更 |
+| STEER-242 §5.4 | `src/interface/sync/frontend_pull.rs` | トランザクション外ファイル DL フェーズ追加 |
+| STEER-242 §5.5 | `src/protocol/session/coordinator.rs` | 再生時ローカル参照に変更・不要コード削除 |
+| STEER-242 §5.6 | `src/protocol/session/handlers/mod.rs` | IVR/VB イントロ音声を `resolve_audio_file_url()` に統一（未適用箇所のみ） |
+| STEER-242 §5.2 | `src/shared/config/mod.rs` | `ANNOUNCEMENT_AUDIO_DIR` 追加 |
+
+---
+
+## 7. レビューチェックリスト
+
+### 7.1 仕様レビュー（Review → Approved）
+
+- [ ] `ANNOUNCEMENT_AUDIO_DIR` のデフォルト値（`data/announcements`）・相対パス基準の説明に合意しているか
+- [ ] DB スキーマ変更なし・`announcements.updated_at` に Frontend `updatedAt` を保存する方針に合意しているか
+- [ ] ファイル DL フェーズ（Phase 1）を DB トランザクション外に置く構造に合意しているか
+- [ ] tmp→rename の原子的書き込みパターンで部分ファイルリスクが解消されているか確認できているか
+- [ ] DL 失敗時「メタデータ同期継続・キャッシュ更新のみスキップ」に合意しているか
+- [ ] `map_audio_file_url_to_local_path()` 削除による既存環境への影響が `.env.example` で説明されているか
+- [ ] `fetch_audio_to_temp()` / `audio_tmp_files` の削除スコープが本 Issue に含まれることに合意しているか
+
+### 7.2 マージ前チェック（Approved → Merged）
+
+- [ ] serversync 実行後、`ANNOUNCEMENT_AUDIO_DIR` に音声ファイルが保存されている
+- [ ] フロントエンド PC 停止中でも AN アナウンスが再生される（AC-1）
+- [ ] フロントエンド PC 停止中でも IVR メニュー音声・VB イントロ音声が再生される（AC-7）
+- [ ] アナウンス更新後の次回 serversync で音声ファイルが再ダウンロードされる（AC-3・updated_at 変化）
+- [ ] ローカルファイル削除後の次回 serversync で音声ファイルが補完ダウンロードされる（AC-3・ファイル不存在）
+- [ ] アナウンス削除後の次回 serversync でローカルファイルが削除される（AC-4）
+- [ ] ダウンロード途中でプロセスが停止した場合に `*.tmp` ファイルが残存するのみで、`.wav` が壊れない
+- [ ] DL 失敗時に WARN ログが出て DB メタデータ同期が継続されることを確認している（AC-5）
+- [ ] ローカルキャッシュ未存在時に WARN ログが出てフォールバック再生される（AC-6）
+- [ ] `audio_tmp_files` フィールド削除後にコンパイルエラーが出ないことを確認している
+
+---
+
+## 8. 未確定点・質問（全確定）
+
+| # | 質問 | 推奨 | オーナー回答 |
+|---|------|------|-------------|
+| Q1 | 音声ダウンロード失敗時の同期継続方針は？ | A: WARN ログのみで継続 | **A（はい）** |
+| Q2 | ダウンロード要否判定を「ファイル不存在 OR updated_at 変化」の両方にするか？ | A: 両方 | **A（両方）** |
+| Q3 | `map_audio_file_url_to_local_path()` へのフォールバックを残さないか？ | A: 残さない | **A（不要）** |
+| Q4 | IVR/VB イントロ音声も `resolve_audio_file_url()` に統一するか？ | B: 全廃で一貫性を保つ | **B（横展開する）** |
+| Q5（レビュー追加）| `announcements.updated_at` を Frontend `updatedAt` に合わせるか？ | Frontend 値を保存 | **はい（NOW() 運用を変更）** |
+| Q6（レビュー追加）| DL 失敗時は「DB メタデータ同期・キャッシュのみスキップ」で確定か？ | DB は同期 | **はい（確定）** |
+| Q7（レビュー追加）| serversync のファイル I/O は DB トランザクション外に出すか？ | トランザクション外 | **はい（トランザクション外でDL→トランザクション内でDB反映）** |
+
+---
+
+## 9. リスク・ロールバック観点
+
+| リスク | 影響 | 緩和策 |
+|--------|------|--------|
+| serversync が一度も成功していない初期状態でアナウンス再生 | ローカルファイル未存在 → WARN + フォールバック音声 | `.env.example` に serversync 先行実行の注意を記載 |
+| `ANNOUNCEMENT_AUDIO_DIR` のディスク容量不足 | ダウンロード失敗 → WARN ログ。tmp ファイルは削除される。既存ファイルは保持 | 運用ドキュメントでディスク容量の目安を案内 |
+| `map_audio_file_url_to_local_path()` 削除による同一マシン構成の変更 | `ANNOUNCEMENT_AUDIO_DIR` を設定しない場合、音声が見つからない | `.env.example` に移行案（絶対パス設定例）を明記 |
+| Phase 1 後・Phase 2 前にプロセスが停止（更新ケース） | ファイルのみ更新、DB は古い `updated_at` のまま残る。次回 serversync で `updated_at` 比較により再 DL されるため最終的に整合 | 許容（ベストエフォート） |
+| Phase 1 でファイル削除後・Phase 2 が失敗（削除ケース） | DB に行が残るがローカルファイルは消えた状態。再生時は「ローカルキャッシュなし → WARN + フォールバック音声」。次回 serversync の Phase 2 成功時に DB 削除が追随して整合 | 許容（ベストエフォート）。Phase 2 失敗は DB 例外としてログ出力される |
+| `*.tmp` ファイルの残存（プロセス強制終了等） | 次回 DL 時に上書きされる（`File::create` で再作成）。再生には使われない（`.wav` 拡張子でない） | 許容。必要なら起動時に `*.tmp` の清掃を行う（別 Issue） |
+| `fetch_audio_to_temp()` / `audio_tmp_files` 削除（STEER-227 実装の全面変更） | 変更範囲が広い | STEER-227 の変更ファイルと重複するため差分を慎重に確認 |
+
+**ロールバック手順:** PR を revert。`ANNOUNCEMENT_AUDIO_DIR` のローカル音声ファイルは手動削除（または放置可。再 DL 時に上書き）。
+変更ファイルは `converters.rs` / `frontend_pull.rs`（または `audio_downloader.rs`）/ `coordinator.rs` / `handlers/mod.rs` / `config/mod.rs` / `.env.example`。
+
+---
+
+## 変更履歴
+
+| 日付 | 変更内容 | 作成者 |
+|------|---------|--------|
+| 2026-02-24 | 承認（§1 ステータス Approved・§3.4 承認情報記入） | @MasanoriSuda |
+| 2026-02-24 | 初版作成（Draft） | Claude Sonnet 4.6 |
+| 2026-02-24 | Q1〜Q4 オーナー回答記入。§2.2/2.3 IVR/VB スコープ明記（Q4）、§3.6 handlers/mod.rs 追加、§4.2 削除コード明記・handlers/mod.rs 追加、§5.4 map_audio_file_url_to_local_path 削除明記（Q3）、§5.5 IVR/VB 変更仕様追加（Q4）、§5.6 FRONTEND_BASE_URL 未設定時の挙動と .env.example 例を更新（Q3）、§7.1/7.2 チェック項目更新、§9 リスク更新 | Claude Sonnet 4.6 |
+| 2026-02-24 | Codex レビュー Round 2 OK 対応（軽①: §5.4.1 updated_at=None 時は比較スキップ・ファイル不存在のみ判定と明記、軽②: §9 に削除先行→Phase 2 失敗の一時不整合リスク追記） | Claude Sonnet 4.6 |
+| 2026-02-24 | Codex レビュー Round 1 NG 対応（Q5/Q6/Q7 オーナー確認後反映）: §3.3 レビュー記入、§3.6 frontend_pull.rs 追加、§4.2 frontend_pull.rs・DTO 変更行追加、§5.3 FrontendAnnouncement DTO・updated_at 保存変更追加（重大①）、§5.4 Phase 1/2 分離（トランザクション外ファイルI/O、重大②）・audio_file_url=None 説明修正（軽①）・tmp→rename 原子的書き込み追加（重大③）・DL失敗時スコープ明確化（中①）、§5.2 相対パス基準明記（中②）、§5.7 .env.example 絶対パス例に更新、§7.1/7.2 チェック項目追加、§8 Q5/Q6/Q7 追加、§9 Phase 間停止リスク・tmp 残存リスク追加 | Claude Sonnet 4.6 |

--- a/virtual-voicebot-backend/src/interface/sync/converters.rs
+++ b/virtual-voicebot-backend/src/interface/sync/converters.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sqlx::{Postgres, Row, Transaction};
@@ -104,6 +105,7 @@ pub struct FrontendAnnouncement {
     pub tts_text: Option<String>,
     pub duration_sec: Option<f64>,
     pub language: Option<String>,
+    pub updated_at: Option<String>,
 }
 
 pub fn default_anonymous_action() -> StoredAction {
@@ -361,12 +363,17 @@ async fn convert_announcements(
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .unwrap_or("ja");
+        let updated_at = announcement
+            .updated_at
+            .as_ref()
+            .and_then(|value| parse_frontend_updated_at(value))
+            .unwrap_or_else(Utc::now);
         sqlx::query(
             "INSERT INTO announcements (
                 id, name, description, announcement_type, is_active, folder_id,
                 audio_file_url, tts_text, duration_sec, language, version, created_at, updated_at
              )
-             VALUES ($1, $2, $3, $4, $5, NULL, $6, $7, $8, $9, 1, NOW(), NOW())
+             VALUES ($1, $2, $3, $4, $5, NULL, $6, $7, $8, $9, 1, NOW(), $10)
              ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
                 description = EXCLUDED.description,
@@ -377,7 +384,7 @@ async fn convert_announcements(
                 tts_text = EXCLUDED.tts_text,
                 duration_sec = EXCLUDED.duration_sec,
                 language = EXCLUDED.language,
-                updated_at = NOW()",
+                updated_at = EXCLUDED.updated_at",
         )
         .bind(announcement.id)
         .bind(announcement.name.trim())
@@ -388,6 +395,7 @@ async fn convert_announcements(
         .bind(tts_text)
         .bind(duration_sec)
         .bind(language)
+        .bind(updated_at)
         .execute(&mut **tx)
         .await?;
     }
@@ -679,6 +687,12 @@ fn normalize_optional_text(raw: Option<&str>) -> Option<String> {
     raw.map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn parse_frontend_updated_at(raw: &str) -> Option<DateTime<Utc>> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&Utc))
 }
 
 fn normalize_action_code(raw: &str) -> String {

--- a/virtual-voicebot-backend/src/interface/sync/frontend_pull.rs
+++ b/virtual-voicebot-backend/src/interface/sync/frontend_pull.rs
@@ -1,19 +1,25 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
 use serde::Deserialize;
 use sqlx::postgres::PgPoolOptions;
-use sqlx::{PgPool, Postgres, Transaction};
+use sqlx::{PgPool, Postgres, Row, Transaction};
 use thiserror::Error;
+use tokio::io::AsyncWriteExt;
 use tokio::time::{interval, MissedTickBehavior};
+use uuid::Uuid;
 
 use crate::interface::sync::converters::{
     apply_frontend_snapshot, default_anonymous_action, default_default_action, CallActionsPayload,
     CallerGroup, ConverterError, FrontendAnnouncement, IvrFlowDefinition, StoredAction,
 };
-use crate::shared::config::SyncConfig;
+use crate::shared::config::{self, SyncConfig};
 
 const FRONTEND_PULL_MAX_CONNECTIONS: u32 = 5;
+const MAX_ANNOUNCEMENT_AUDIO_BYTES: u64 = 8 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct FrontendPullWorker {
@@ -73,6 +79,12 @@ struct AnnouncementsResponse {
     error: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+struct ExistingAnnouncementAudioState {
+    audio_file_url: Option<String>,
+    updated_at: DateTime<Utc>,
+}
+
 impl FrontendPullWorker {
     pub async fn new(database_url: String, config: SyncConfig) -> Result<Self, FrontendPullError> {
         let timeout = Duration::from_secs(config.timeout_sec);
@@ -127,6 +139,12 @@ impl FrontendPullWorker {
             "[serversync] GET /api/ivr-flows/export: success flows={}",
             flows.len()
         );
+        if let Err(error) = self.sync_announcement_audio_cache(&announcements).await {
+            log::warn!(
+                "[serversync] announcement audio cache sync failed: {}",
+                error
+            );
+        }
 
         self.save_snapshot(&groups, &actions, &announcements, &flows)
             .await?;
@@ -254,11 +272,270 @@ impl FrontendPullWorker {
         tx.commit().await?;
         Ok(())
     }
+
+    async fn sync_announcement_audio_cache(
+        &self,
+        announcements: &[FrontendAnnouncement],
+    ) -> Result<(), FrontendPullError> {
+        let cfg = config::announcement_config();
+        if cfg.frontend_base_url.is_none() {
+            log::info!(
+                "[serversync] announcement audio cache sync skipped: FRONTEND_BASE_URL not set"
+            );
+            return Ok(());
+        }
+
+        let existing = self.load_existing_announcement_audio_state().await?;
+        let frontend_ids: HashSet<Uuid> = announcements
+            .iter()
+            .map(|announcement| announcement.id)
+            .collect();
+        let audio_dir = Path::new(cfg.audio_dir.as_str());
+
+        for (id, state) in &existing {
+            if frontend_ids.contains(id) {
+                continue;
+            }
+            let Some(audio_file_url) = state.audio_file_url.as_deref() else {
+                continue;
+            };
+            let url_path = extract_url_path(audio_file_url);
+            if !is_safe_announcement_url_path(url_path.as_str()) {
+                log::warn!(
+                    "[serversync] skip deleting cached audio for removed announcement id={} invalid audio_file_url={}",
+                    id,
+                    audio_file_url
+                );
+                continue;
+            }
+            let local_path = announcement_cache_local_path(audio_dir, url_path.as_str());
+            if let Err(err) = remove_file_if_exists(local_path.as_path()).await {
+                log::warn!(
+                    "[serversync] failed to delete cached audio for removed announcement id={} path={} err={}",
+                    id,
+                    local_path.display(),
+                    err
+                );
+            }
+        }
+
+        for announcement in announcements {
+            let Some(audio_file_url) = announcement.audio_file_url.as_deref() else {
+                continue;
+            };
+            let url_path = extract_url_path(audio_file_url);
+            if !is_safe_announcement_url_path(url_path.as_str()) {
+                log::warn!(
+                    "[serversync] skip cached audio sync for announcement id={} invalid audio_file_url={}",
+                    announcement.id,
+                    audio_file_url
+                );
+                continue;
+            }
+
+            let local_path = announcement_cache_local_path(audio_dir, url_path.as_str());
+            if !should_download_announcement_audio(
+                local_path.as_path(),
+                announcement.updated_at.as_deref(),
+                existing.get(&announcement.id),
+            ) {
+                continue;
+            }
+
+            if let Err(err) = download_audio_file(
+                &self.http_client,
+                self.frontend_base_url.as_str(),
+                url_path.as_str(),
+                local_path.as_path(),
+            )
+            .await
+            {
+                log::warn!(
+                    "[serversync] failed to cache announcement audio id={} url={} path={} err={:?}",
+                    announcement.id,
+                    url_path,
+                    local_path.display(),
+                    err
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn load_existing_announcement_audio_state(
+        &self,
+    ) -> Result<HashMap<Uuid, ExistingAnnouncementAudioState>, FrontendPullError> {
+        let rows = sqlx::query("SELECT id, audio_file_url, updated_at FROM announcements")
+            .fetch_all(&self.pool)
+            .await?;
+        let mut map = HashMap::with_capacity(rows.len());
+        for row in rows {
+            let id: Uuid = row.try_get("id")?;
+            let audio_file_url: Option<String> = row.try_get("audio_file_url")?;
+            let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+            map.insert(
+                id,
+                ExistingAnnouncementAudioState {
+                    audio_file_url,
+                    updated_at,
+                },
+            );
+        }
+        Ok(map)
+    }
+}
+
+fn should_download_announcement_audio(
+    local_path: &Path,
+    frontend_updated_at_raw: Option<&str>,
+    existing: Option<&ExistingAnnouncementAudioState>,
+) -> bool {
+    if !local_path.exists() {
+        return true;
+    }
+
+    let Some(frontend_updated_at) = frontend_updated_at_raw.and_then(parse_frontend_updated_at)
+    else {
+        return false;
+    };
+
+    match existing {
+        Some(state) => state.updated_at != frontend_updated_at,
+        None => true,
+    }
+}
+
+fn parse_frontend_updated_at(raw: &str) -> Option<DateTime<Utc>> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+}
+
+async fn download_audio_file(
+    http_client: &reqwest::Client,
+    frontend_base_url: &str,
+    url_path: &str,
+    local_path: &Path,
+) -> anyhow::Result<()> {
+    debug_assert!(is_safe_announcement_url_path(url_path));
+
+    let full_url = format!("{}{}", frontend_base_url.trim_end_matches('/'), url_path);
+    let mut resp = http_client
+        .get(&full_url)
+        .send()
+        .await?
+        .error_for_status()?;
+    if let Some(content_length) = resp
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+    {
+        if content_length > MAX_ANNOUNCEMENT_AUDIO_BYTES {
+            return Err(anyhow::anyhow!(
+                "audio response too large: content-length={} max={} url={}",
+                content_length,
+                MAX_ANNOUNCEMENT_AUDIO_BYTES,
+                full_url
+            ));
+        }
+    }
+
+    let parent = local_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("local_path has no parent: {}", local_path.display()))?;
+    tokio::fs::create_dir_all(parent).await?;
+
+    let tmp_path = local_path.with_extension("tmp");
+    let write_result: anyhow::Result<()> = async {
+        let mut file = tokio::fs::File::create(&tmp_path).await?;
+        let mut total_bytes = 0_u64;
+        while let Some(chunk) = resp.chunk().await? {
+            total_bytes = total_bytes
+                .checked_add(chunk.len() as u64)
+                .ok_or_else(|| anyhow::anyhow!("audio response size overflow url={}", full_url))?;
+            if total_bytes > MAX_ANNOUNCEMENT_AUDIO_BYTES {
+                return Err(anyhow::anyhow!(
+                    "audio response exceeded max size while streaming: size={} max={} url={}",
+                    total_bytes,
+                    MAX_ANNOUNCEMENT_AUDIO_BYTES,
+                    full_url
+                ));
+            }
+            file.write_all(&chunk).await?;
+        }
+        file.flush().await?;
+        Ok(())
+    }
+    .await;
+
+    if let Err(err) = write_result {
+        tokio::fs::remove_file(&tmp_path).await.ok();
+        return Err(err);
+    }
+
+    if let Err(err) = tokio::fs::rename(&tmp_path, local_path).await {
+        tokio::fs::remove_file(&tmp_path).await.ok();
+        return Err(err.into());
+    }
+    Ok(())
+}
+
+async fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+fn extract_url_path(audio_file_url: &str) -> String {
+    let trimmed = audio_file_url.trim();
+    let without_fragment = trimmed.split('#').next().unwrap_or(trimmed);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    if let Some(scheme_sep) = without_query.find("://") {
+        let after_scheme = &without_query[scheme_sep + 3..];
+        if let Some(path_pos) = after_scheme.find('/') {
+            return after_scheme[path_pos..].to_string();
+        }
+        return "/".to_string();
+    }
+    without_query.to_string()
+}
+
+fn is_safe_announcement_url_path(url_path: &str) -> bool {
+    let Some(rest) = url_path.strip_prefix("/audio/announcements/") else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+    !rest.contains('/')
+        && rest != "."
+        && rest != ".."
+        && !rest.contains('%')
+        && !rest.contains('\\')
+}
+
+fn announcement_cache_local_path(audio_dir: &Path, url_path: &str) -> PathBuf {
+    let filename = url_path
+        .rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("invalid.wav");
+    audio_dir.join(filename)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AnnouncementsResponse, CallActionsResponse, NumberGroupsResponse};
+    use super::{
+        extract_url_path, is_safe_announcement_url_path, AnnouncementsResponse,
+        CallActionsResponse, NumberGroupsResponse,
+    };
 
     #[test]
     fn number_groups_response_accepts_camel_case_fields() {
@@ -279,9 +556,23 @@ mod tests {
 
     #[test]
     fn announcements_response_accepts_announcement_list() {
-        let raw = r#"{"ok":true,"announcements":[{"id":"11111111-1111-4111-8111-111111111111","name":"greeting","announcementType":"custom","isActive":true,"audioFileUrl":"/audio/announcements/a.wav"}]}"#;
+        let raw = r#"{"ok":true,"announcements":[{"id":"11111111-1111-4111-8111-111111111111","name":"greeting","announcementType":"custom","isActive":true,"audioFileUrl":"/audio/announcements/a.wav","updatedAt":"2026-02-24T12:34:56.000Z"}]}"#;
         let parsed: AnnouncementsResponse = serde_json::from_str(raw).expect("valid response");
         assert!(parsed.ok);
         assert_eq!(parsed.announcements.len(), 1);
+        assert!(parsed.announcements[0].updated_at.is_some());
+    }
+
+    #[test]
+    fn extract_url_path_strips_query_and_fragment() {
+        let path = extract_url_path("http://localhost:3000/audio/announcements/a.wav?v=2#section");
+        assert_eq!(path, "/audio/announcements/a.wav");
+    }
+
+    #[test]
+    fn safe_announcement_url_path_rejects_subdirectories() {
+        assert!(!is_safe_announcement_url_path(
+            "/audio/announcements/morning/greeting.wav"
+        ));
     }
 }

--- a/virtual-voicebot-backend/src/protocol/session/coordinator.rs
+++ b/virtual-voicebot-backend/src/protocol/session/coordinator.rs
@@ -126,7 +126,6 @@ pub struct SessionCoordinator {
     transfer_after_answer_pending: bool,
     announcement_id: Option<Uuid>,
     announcement_audio_file_url: Option<String>,
-    audio_tmp_files: Vec<tempfile::NamedTempFile>,
     ivr_flow_id: Option<Uuid>,
     ivr_menu_audio_file_url: Option<String>,
     ivr_keypad_node_id: Option<Uuid>,
@@ -226,7 +225,6 @@ impl SessionCoordinator {
             transfer_after_answer_pending: false,
             announcement_id: None,
             announcement_audio_file_url: None,
-            audio_tmp_files: Vec::new(),
             ivr_flow_id: None,
             ivr_menu_audio_file_url: None,
             ivr_keypad_node_id: None,
@@ -544,35 +542,37 @@ impl SessionCoordinator {
 
     async fn resolve_audio_file_url(&mut self, audio_file_url: String) -> Option<String> {
         let cfg = config::announcement_config();
-        if let Some(base_url) = cfg.frontend_base_url.as_deref() {
+        let Some(local_path) =
+            map_audio_file_url_to_cache_path(cfg.audio_dir.as_str(), &audio_file_url)
+        else {
             let url_path = extract_url_path(&audio_file_url);
-            if !is_safe_announcement_url_path(&url_path) {
-                log::warn!(
-                    "[session {}] rejected unsafe audio url path: {}",
-                    self.call_id,
-                    url_path
-                );
-                return None;
-            }
+            log::warn!(
+                "[session {}] rejected unsafe audio url path: {}",
+                self.call_id,
+                url_path
+            );
+            return None;
+        };
 
-            match fetch_audio_to_temp(url_path.as_str(), base_url).await {
-                Ok(tmp_file) => {
-                    let path = tmp_file.path().to_string_lossy().to_string();
-                    self.audio_tmp_files.push(tmp_file);
-                    Some(path)
-                }
-                Err(err) => {
-                    log::warn!(
-                        "[session {}] failed to fetch audio from {} err={:?}",
-                        self.call_id,
-                        base_url,
-                        err
-                    );
-                    None
-                }
+        match tokio::fs::metadata(&local_path).await {
+            Ok(_) => Some(local_path),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                log::warn!(
+                    "[session {}] local audio cache not found: {} (has serversync run?)",
+                    self.call_id,
+                    local_path
+                );
+                None
             }
-        } else {
-            Some(map_audio_file_url_to_local_path(audio_file_url))
+            Err(err) => {
+                log::warn!(
+                    "[session {}] failed to check local audio cache {}: {}",
+                    self.call_id,
+                    local_path,
+                    err
+                );
+                None
+            }
         }
     }
 
@@ -712,69 +712,21 @@ impl SessionCoordinator {
     }
 }
 
-async fn fetch_audio_to_temp(
-    relative_url_path: &str,
-    frontend_base_url: &str,
-) -> anyhow::Result<tempfile::NamedTempFile> {
-    const MAX_REMOTE_ANNOUNCEMENT_AUDIO_BYTES: u64 = 8 * 1024 * 1024;
-
-    debug_assert!(is_safe_announcement_url_path(relative_url_path));
-
-    let full_url = format!(
-        "{}{}",
-        frontend_base_url.trim_end_matches('/'),
-        relative_url_path
-    );
-    let client = reqwest::Client::builder()
-        .timeout(config::timeouts().ai_http)
-        .build()?;
-    let mut resp = client.get(&full_url).send().await?.error_for_status()?;
-    if let Some(content_length) = resp
-        .headers()
-        .get(reqwest::header::CONTENT_LENGTH)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
-    {
-        if content_length > MAX_REMOTE_ANNOUNCEMENT_AUDIO_BYTES {
-            return Err(anyhow::anyhow!(
-                "audio response too large: content-length={} max={} url={}",
-                content_length,
-                MAX_REMOTE_ANNOUNCEMENT_AUDIO_BYTES,
-                full_url
-            ));
-        }
-    }
-
-    let mut tmp = tempfile::NamedTempFile::new()?;
-    use std::io::Write as _;
-    let mut total_bytes = 0_u64;
-    while let Some(chunk) = resp.chunk().await? {
-        total_bytes = total_bytes
-            .checked_add(chunk.len() as u64)
-            .ok_or_else(|| anyhow::anyhow!("audio response size overflow url={}", full_url))?;
-        if total_bytes > MAX_REMOTE_ANNOUNCEMENT_AUDIO_BYTES {
-            return Err(anyhow::anyhow!(
-                "audio response exceeded max size while streaming: size={} max={} url={}",
-                total_bytes,
-                MAX_REMOTE_ANNOUNCEMENT_AUDIO_BYTES,
-                full_url
-            ));
-        }
-        tmp.write_all(&chunk)?;
-    }
-    Ok(tmp)
-}
-
 fn extract_url_path(audio_file_url: &str) -> String {
     let trimmed = audio_file_url.trim();
-    if let Some(scheme_sep) = trimmed.find("://") {
-        let after_scheme = &trimmed[scheme_sep + 3..];
+    let without_fragment = trimmed.split('#').next().unwrap_or(trimmed);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    if let Some(scheme_sep) = without_query.find("://") {
+        let after_scheme = &without_query[scheme_sep + 3..];
         if let Some(path_pos) = after_scheme.find('/') {
             return after_scheme[path_pos..].to_string();
         }
         return "/".to_string();
     }
-    trimmed.to_string()
+    without_query.to_string()
 }
 
 fn is_safe_announcement_url_path(url_path: &str) -> bool {
@@ -784,36 +736,24 @@ fn is_safe_announcement_url_path(url_path: &str) -> bool {
     if rest.is_empty() {
         return false;
     }
-    !rest.split('/').any(|seg| {
-        seg.is_empty() || seg == "." || seg == ".." || seg.contains('%') || seg.contains('\\')
-    })
+    !rest.contains('/')
+        && rest != "."
+        && rest != ".."
+        && !rest.contains('%')
+        && !rest.contains('\\')
 }
 
-fn map_audio_file_url_to_local_path(audio_file_url: String) -> String {
-    let url_path = extract_url_path(&audio_file_url);
-
-    if is_safe_announcement_url_path(&url_path) {
-        let rest = url_path
-            .strip_prefix("/audio/announcements/")
-            .expect("validated prefix");
-        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_else(|| std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")));
-        let path = repo_root
-            .join("virtual-voicebot-frontend")
-            .join("public")
-            .join("audio")
-            .join("announcements")
-            .join(rest);
-        return path.to_string_lossy().to_string();
+fn map_audio_file_url_to_cache_path(audio_dir: &str, audio_file_url: &str) -> Option<String> {
+    let url_path = extract_url_path(audio_file_url);
+    if !is_safe_announcement_url_path(&url_path) {
+        return None;
     }
-
-    if let Some(path) = url_path.strip_prefix("file://") {
-        return path.to_string();
-    }
-
-    url_path
+    let filename = url_path
+        .rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())?;
+    let path = std::path::Path::new(audio_dir).join(filename);
+    Some(path.to_string_lossy().to_string())
 }
 
 fn normalize_action_code(action_code: &str) -> String {
@@ -1037,7 +977,6 @@ mod tests {
             transfer_after_answer_pending: false,
             announcement_id: None,
             announcement_audio_file_url: None,
-            audio_tmp_files: Vec::new(),
             ivr_flow_id: None,
             ivr_menu_audio_file_url: None,
             ivr_keypad_node_id: None,
@@ -1169,17 +1108,22 @@ mod tests {
     }
 
     #[test]
-    fn audio_announcement_url_is_mapped_to_frontend_public_file() {
-        let mapped = super::map_audio_file_url_to_local_path(
-            "http://localhost:3000/audio/announcements/abc.wav".to_string(),
-        );
-        assert!(mapped.ends_with("virtual-voicebot-frontend/public/audio/announcements/abc.wav"));
+    fn audio_announcement_url_is_mapped_to_local_cache_dir() {
+        let mapped = super::map_audio_file_url_to_cache_path(
+            "/tmp/announcements",
+            "http://localhost:3000/audio/announcements/abc.wav",
+        )
+        .expect("valid cache path");
+        assert_eq!(mapped, "/tmp/announcements/abc.wav");
     }
 
     #[test]
-    fn relative_audio_announcement_url_is_mapped_to_frontend_public_file() {
-        let mapped = super::map_audio_file_url_to_local_path("/audio/announcements/xyz.wav".into());
-        assert!(mapped.ends_with("virtual-voicebot-frontend/public/audio/announcements/xyz.wav"));
+    fn invalid_audio_announcement_url_is_rejected_for_local_cache() {
+        let mapped = super::map_audio_file_url_to_cache_path(
+            "/tmp/announcements",
+            "/audio/announcements/../../../etc/passwd",
+        );
+        assert!(mapped.is_none());
     }
 
     #[test]
@@ -1192,6 +1136,13 @@ mod tests {
     fn extract_url_path_keeps_relative_path() {
         let path = super::extract_url_path("/audio/announcements/b.wav");
         assert_eq!(path, "/audio/announcements/b.wav");
+    }
+
+    #[test]
+    fn extract_url_path_strips_query_and_fragment() {
+        let path =
+            super::extract_url_path("http://192.168.1.5:3000/audio/announcements/a.wav?v=2#x");
+        assert_eq!(path, "/audio/announcements/a.wav");
     }
 
     #[test]
@@ -1219,6 +1170,13 @@ mod tests {
     fn safe_announcement_url_path_accepts_normal_announcement_path() {
         assert!(super::is_safe_announcement_url_path(
             "/audio/announcements/abc-123.wav"
+        ));
+    }
+
+    #[test]
+    fn safe_announcement_url_path_rejects_subdirectories() {
+        assert!(!super::is_safe_announcement_url_path(
+            "/audio/announcements/morning/greeting.wav"
         ));
     }
 

--- a/virtual-voicebot-backend/src/protocol/session/handlers/mod.rs
+++ b/virtual-voicebot-backend/src/protocol/session/handlers/mod.rs
@@ -1706,7 +1706,6 @@ mod tests {
             transfer_after_answer_pending: false,
             announcement_id: None,
             announcement_audio_file_url: None,
-            audio_tmp_files: Vec::new(),
             ivr_flow_id: None,
             ivr_menu_audio_file_url: None,
             ivr_keypad_node_id: None,

--- a/virtual-voicebot-backend/src/shared/config/mod.rs
+++ b/virtual-voicebot-backend/src/shared/config/mod.rs
@@ -527,12 +527,22 @@ impl SyncConfig {
 #[derive(Clone, Debug)]
 pub struct AnnouncementConfig {
     pub frontend_base_url: Option<String>,
+    pub audio_dir: String,
 }
 
 impl AnnouncementConfig {
     fn from_env() -> Self {
+        let audio_dir = env_non_empty("ANNOUNCEMENT_AUDIO_DIR")
+            .unwrap_or_else(|| "data/announcements".to_string());
+        if !std::path::Path::new(&audio_dir).is_absolute() {
+            log::info!(
+                "[config] ANNOUNCEMENT_AUDIO_DIR is a relative path: '{}' (resolved against CWD)",
+                audio_dir
+            );
+        }
         Self {
             frontend_base_url: env_non_empty("FRONTEND_BASE_URL"),
+            audio_dir,
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アナウンスメントオーディオのローカルキャッシング機能を追加しました。フロントエンドの状態に依存せずに音声再生が可能になります。

* **改善**
  * オーディオの同期と取得プロセスを最適化しました。音声ファイルの管理がより効率的になります。
  * アナウンスメント設定で新しい環境変数オプションを追加しました。

* **ドキュメント**
  * キャッシュディレクトリの設定とデプロイに関するガイドを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->