### PR TITLE
#275 発信履歴の表示バグを修正 

### DIFF
--- a/docs/steering/STEER-275_outbound-call-history-display.md
+++ b/docs/steering/STEER-275_outbound-call-history-display.md
@@ -1,0 +1,495 @@
+# STEER-275: フロントエンド発着信履歴の発信時表示修正
+
+---
+
+## 1. メタ情報
+
+| 項目 | 値 |
+|------|-----|
+| ID | STEER-275 |
+| タイトル | フロントエンド発着信履歴の発信時表示修正 |
+| ステータス | Approved |
+| 関連Issue | #275 |
+| 優先度 | P1 |
+| 作成日 | 2026-03-02 |
+
+---
+
+## 2. ストーリー（Why）
+
+### 2.1 背景
+
+- Issue #272（STEER-272）にてバックエンドの発着信同時サポートが実装されたが、フロントエンドの発着信履歴画面は発信通話を想定した作り込みをしていなかった。
+- 実際に発信が行われた通話ログを確認すると、以下の不正表示が確認されている：
+
+| 列 | 現状（不正） | 期待 |
+|----|-------------|------|
+| 方向 | 着信 | 発信 |
+| 発信者 | 未登録 / 非通知 | 発信元番号（登録 SIP ユーザー）|
+| 着信先 | 未設定 | 発信先番号（顧客電話番号）|
+
+- フロントエンドは方向を `actionCode === "AR"` の場合のみ「発信」と判定しているが、STEER-272 で実装されたの発信通話（B2BUA 転送）は AI パイプラインを使用しないため、`actionCode` が "AR" ではない可能性がある（ログ上では VB = ボイスボットが表示されている）。
+- バックエンドの API レスポンスには `direction`（発信/着信）フィールドが含まれておらず、フロントエンドが方向を正確に判定できない。
+- 着信先（発信先番号）の情報もAPIレスポンスに含まれていない。
+
+### 2.2 目的
+
+- 発信通話の履歴表示を正しくする：
+  1. **方向列**：発信バッジ（「発信」+PhoneOutgoing アイコン）を正しく表示する
+  2. **発信者列**：発信元番号（登録 SIP ユーザー番号）を表示する
+  3. **着信先列**：発信先番号（顧客電話番号）を表示する
+  4. **その他列**：発信時に意味を持たない列（着信応答・IVR詳細等）を「-」表示にする
+  5. **ステータス**：発信通話の displayStatus を定義する
+- バックエンドが `direction` および `calleeNumber` をAPIレスポンスに含めることで、フロントエンドが信頼性高く判定できるようにする。
+
+### 2.3 ユーザーストーリー
+
+```
+As a 管理者
+I want to 発着信履歴で発信通話を一見して「発信」と判別できる表示にしたい
+So that 着信と発信の通話実績を正確に区別して管理できる
+
+受入条件:
+- [ ] AC-1: direction = "outbound" の通話は 方向列に「発信」バッジ（PhoneOutgoing アイコン、emerald 色）が表示される
+- [ ] AC-2: direction = "outbound" の通話は 発信者列に発信元番号（callerNumber、登録 SIP ユーザー番号）が表示される
+- [ ] AC-3: direction = "outbound" の通話は 着信先列に発信先番号（calleeNumber）が表示される
+- [ ] AC-4: direction = "outbound" の通話の 着信応答列 は "-" が表示される
+- [ ] AC-5: direction = "outbound" の通話の IVR詳細列 は "-" が表示される
+- [ ] AC-6: direction = "outbound" 通話の displayStatus は §5.10 で定義したルールで決定される
+- [ ] AC-7: フィルタバーで「発信」を選択した場合、direction = "outbound" の通話のみ絞り込まれる
+- [ ] AC-8: CSV エクスポートの「方向」列に「発信」と出力される
+- [ ] AC-9: 通話詳細 Drawer（call-detail-drawer）でも発信通話の表示が正しく行われる
+- [ ] AC-10: バックエンド API レスポンスに direction（"inbound" | "outbound"）が含まれる
+- [ ] AC-11: バックエンド API レスポンスに calleeNumber（string | null）が含まれる
+```
+
+---
+
+## 3. 段取り（Who / When）
+
+### 3.1 起票
+
+| 項目 | 値 |
+|------|-----|
+| 起票者 | @MasanoriSuda |
+| 起票日 | 2026-03-02 |
+| 起票理由 | #272 発着信サポート実装後、発信通話の履歴表示が発信用に作り込まれていないことが判明 |
+
+### 3.2 仕様作成
+
+| 項目 | 値 |
+|------|-----|
+| 作成者 | Claude Code (claude-sonnet-4-6) |
+| 作成日 | 2026-03-02 |
+| 指示者 | @MasanoriSuda |
+| 指示内容 | "Issue #275 の発着信履歴発信時表示修正のステアリングを作成" |
+
+### 3.3 レビュー
+
+| # | レビュアー | 日付 | 結果 | コメント |
+|---|-----------|------|------|---------|
+| 1 | @MasanoriSuda | 2026-03-02 | OK | lgtm |
+
+### 3.4 承認
+
+| 項目 | 値 |
+|------|-----|
+| 承認者 | @MasanoriSuda |
+| 承認日 | 2026-03-02 |
+| 承認コメント | lgtm |
+
+### 3.5 実装
+
+| 項目 | 値 |
+|------|-----|
+| 実装者 | Codex |
+| 実装日 | - |
+| 指示者 | @MasanoriSuda |
+| 指示内容 | "STEER-275 に基づき Backend API + Frontend 表示を実装" |
+| コードレビュー | - |
+
+### 3.6 マージ
+
+| 項目 | 値 |
+|------|-----|
+| マージ実行者 | - |
+| マージ日 | - |
+| マージ先 | virtual-voicebot-backend/docs/requirements/RD-001_product.md (F-13 補足), virtual-voicebot-frontend/docs/requirements/RD-005_frontend.md (§3.3 発着信履歴) |
+
+---
+
+## 4. 影響範囲
+
+### 4.1 影響するドキュメント
+
+| ドキュメント | 変更種別 | 概要 |
+|-------------|---------|------|
+| `virtual-voicebot-backend/docs/requirements/RD-001_product.md` | 修正 | F-13「UAC 発信」に履歴表示の要件（direction / calleeNumber の API 返却）を追記 |
+| `virtual-voicebot-frontend/docs/requirements/RD-005_frontend.md` | 修正 | §3.3 発着信履歴の「方向」「発信者」「着信先」列の発信時仕様を追記 |
+
+### 4.2 影響するコード
+
+#### Backend
+
+| モジュール | 変更種別 | 概要 |
+|-----------|---------|------|
+| `migrations/YYYYMMDD_add_direction_callee_number.sql` | 追加 | call_logs テーブルに `direction` / `callee_number` カラムを追加 |
+| `src/shared/ports/call_log_port.rs` | 修正 | `EndedCallLog` 構造体に `direction: String` / `callee_number: Option<String>` を追加 |
+| `src/interface/db/postgres.rs` | 修正 | sync payload に `direction` / `calleeNumber` を追加 |
+| `src/protocol/session/coordinator.rs` | 修正 | 通話終了時に `direction`（"inbound" / "outbound"）と `callee_number` を `EndedCallLog` へ設定 |
+
+#### Frontend
+
+| モジュール | 変更種別 | 概要 |
+|-----------|---------|------|
+| `lib/db/sync.ts` | 修正 | `StoredCallLog` 型に `direction: string` / `calleeNumber: string \| null` を追加。`normalizeCallLog()` で Backend payload から `direction` / `calleeNumber` をパース |
+| `lib/api.ts` | 修正 | `mapStoredCallToCall()` に `direction` / `calleeNumber` のマッピングを追加 |
+| `lib/db/queries.ts` | 修正 | `deriveDirection()` を `callLog.direction` 優先に変更（`callLog.direction === "outbound"` を先に評価し、fallback として `actionCode === "AR"` を維持） |
+| `lib/types.ts` | 修正 | `Call` インターフェースに `direction: "inbound" \| "outbound"` / `calleeNumber: string \| null` を追加 |
+| `lib/mock-data.ts` | 修正 | `CallRecord` に対応するフィールドが不足している場合は追加（toRecord 経由で設定される想定） |
+| `lib/call-display.ts` | 修正 | `resolveDisplayStatus()` に発信通話分岐を追加（§5.10 参照） |
+| `components/call-history-content.tsx` | 修正 | `toDirection()` を `call.direction` ベースに変更。`toRecord()` に `calleeNumber` の設定を追加 |
+| `components/calls/calls-table.tsx` | 修正 | 発信時の 着信応答列・IVR詳細列 を "-" 表示。着信先列を direction に応じて calleeNumber に切り替え |
+| `components/calls/call-detail-drawer.tsx` | 修正 | 発信時の各フィールドを正しく表示（着信応答・IVR詳細の "-" 表示等） |
+
+---
+
+## 5. 差分仕様（What / How）
+
+### 5.1 バックエンド: DB スキーマ追加
+
+```sql
+-- migrations/YYYYMMDD_add_direction_callee_number_to_call_logs.sql
+
+ALTER TABLE call_logs
+  ADD COLUMN direction TEXT NOT NULL DEFAULT 'inbound'
+    CHECK (direction IN ('inbound', 'outbound')),
+  ADD COLUMN callee_number TEXT NULL;
+```
+
+> **注**: 既存レコードは `DEFAULT 'inbound'` で補完する（#272 実装以前のレコードはすべて着信のため問題なし）。
+
+### 5.2 バックエンド: EndedCallLog 構造体追加フィールド
+
+```rust
+// src/shared/ports/call_log_port.rs
+
+pub struct EndedCallLog {
+    // ...既存フィールド...
+    pub direction: String,           // "inbound" | "outbound" （追加）
+    pub callee_number: Option<String>, // 発信先番号。着信時は None（追加）
+}
+```
+
+### 5.3 バックエンド: direction / callee_number の設定ルール
+
+| セッション種別 | direction | callee_number |
+|--------------|-----------|---------------|
+| 着信（UAS, `outbound_mode = false`） | `"inbound"` | `None` |
+| 発信（B2BUA, `outbound_mode = true`）| `"outbound"` | `resolve_number(to_user)` 解決後の番号（実際に発呼した番号）|
+
+`SessionCoordinator` の通話終了処理（BYE 受信 / タイムアウト等）で `outbound_mode` を参照して設定する。
+
+> **OQ-5 解決済み**: `callee_number` はダイヤルプラン解決後（`resolve_number()` で得られた実際の発呼番号）を採用する。生の SIP To ユーザー部ではなく、実際に `sip:{number}@{outbound_domain}` として発呼した番号を記録する（[handlers/mod.rs:124](../../virtual-voicebot-backend/src/protocol/session/handlers/mod.rs), [config/mod.rs:560](../../virtual-voicebot-backend/src/shared/config/mod.rs)）。
+
+### 5.4 バックエンド: API レスポンス追加フィールド
+
+```rust
+// src/interface/db/postgres.rs（sync payload）
+
+json!({
+    // ...既存フィールド...
+    "direction": call_log.direction,           // 追加
+    "calleeNumber": call_log.callee_number,    // 追加
+})
+```
+
+### 5.5 フロントエンド: StoredCallLog 型 + normalizeCallLog() の変更
+
+```typescript
+// lib/db/sync.ts
+
+// StoredCallLog 型への追加
+export interface StoredCallLog {
+  // ...既存フィールド...
+  direction: string          // 追加（"inbound" | "outbound"）
+  calleeNumber: string | null  // 追加
+}
+
+// normalizeCallLog() への追加（既存の他フィールドと同形式）
+function normalizeCallLog(entityId: string, payload: unknown, nowIso: string): StoredCallLog {
+  const input = isRecord(payload) ? payload : {}
+  return {
+    // ...既存フィールド...
+    direction: asString(input, ["direction"], "inbound") ?? "inbound",  // 追加
+    calleeNumber: asString(input, ["calleeNumber", "callee_number"], null), // 追加
+  }
+}
+```
+
+### 5.6 フロントエンド: mapStoredCallToCall() の変更
+
+```typescript
+// lib/api.ts
+
+function mapStoredCallToCall(callLog: StoredCallLog): Call {
+  return {
+    // ...既存フィールド...
+    direction: (callLog.direction as Call["direction"]) ?? "inbound",  // 追加
+    calleeNumber: callLog.calleeNumber ?? null,                         // 追加
+  }
+}
+```
+
+### 5.7 フロントエンド: deriveDirection() の変更
+
+```typescript
+// lib/db/queries.ts
+
+// Before
+export function deriveDirection(callLog: StoredCallLog): CallDirection {
+  if (callLog.status === "error" || callLog.endReason === "rejected") return "missed"
+  if (callLog.actionCode === "AR") return "outbound"
+  return "inbound"
+}
+
+// After: StoredCallLog.direction を優先参照し、actionCode === "AR" は後方互換 fallback として残す
+export function deriveDirection(callLog: StoredCallLog): CallDirection {
+  if (callLog.status === "error" || callLog.endReason === "rejected") return "missed"
+  if (callLog.direction === "outbound" || callLog.actionCode === "AR") return "outbound"
+  return "inbound"
+}
+```
+
+### 5.8 フロントエンド: Call インターフェース拡張
+
+```typescript
+// lib/types.ts
+
+export type CallDirection = "inbound" | "outbound"  // 追加
+
+export interface Call {
+  // ...既存フィールド...
+  direction: CallDirection       // 追加（バックエンドから取得）
+  calleeNumber: string | null    // 追加（バックエンドから取得）
+}
+```
+
+### 5.9 フロントエンド: toDirection() の変更
+
+```typescript
+// components/call-history-content.tsx
+
+// Before
+function toDirection(call: Call): CallRecord["direction"] {
+  if (call.status === "error" || call.endReason === "rejected") return "missed"
+  if (call.actionCode === "AR") return "outbound"
+  return "inbound"
+}
+
+// After: direction フィールドを優先使用し、不在判定は現行ロジックを維持
+function toDirection(call: Call): CallRecord["direction"] {
+  if (call.status === "error" || call.endReason === "rejected") return "missed"
+  return call.direction  // バックエンドが設定した "inbound" | "outbound" をそのまま使用
+}
+```
+
+### 5.10 フロントエンド: resolveDisplayStatus() の発信通話分岐追加
+
+発信通話（`direction === "outbound"`）は既存の actionCode ベース分岐の前に評価する。
+
+> **背景**: Backend の `answered_at` は発信通話で現在 `None` 固定（[coordinator.rs:821](../../virtual-voicebot-backend/src/protocol/session/coordinator.rs)）のため、`answeredAt` を判定に使うと常に「応答なし」になる。発信の応答判定は B-leg 応答時刻 `transferAnsweredAt` で行う。
+
+| 優先度 | 条件 | displayStatus |
+|--------|------|---------------|
+| 0 | `status ∈ {"ringing", "in_call"}` | 通話中 |
+| **1 (追加)** | **`direction === "outbound"` AND `transferAnsweredAt !== null`** | **通話終了** |
+| **2 (追加)** | **`direction === "outbound"` AND `transferAnsweredAt === null`** | **応答なし** |
+| 3（旧1） | `callDisposition === "denied"` | 常時着信拒否 |
+| 4（旧2） | `endReason === "cancelled"` AND `answeredAt === null` | 不在着信 |
+| …（旧3〜10） | （STEER-270 §5.2 と同じ） | （変更なし） |
+
+> **OQ-1 解決済み**: 発信時の未応答は新規 `"応答なし"` を使用する。着信側の「不在着信」（相手が出なかった）と発信側の「応答なし」（かけた先が出なかった）は意味が異なるため、混用しない。
+
+> **OQ-3 解決済み**: 発信通話の `actionCode` は発信専用コードではなく、ルーティングルール評価結果（主に `"VR"` / `"IV"` 等）が設定される。Backend では `"AR"` を発信識別コードとしてセットしていないため、フロントエンドの `toDirection()` で `actionCode === "AR"` による発信判定は実質的に機能していない。発信の判定は必ずバックエンドが返す `direction` フィールドを使用すること（[executor.rs](../../virtual-voicebot-backend/src/service/routing/executor.rs), [coordinator.rs:755](../../virtual-voicebot-backend/src/protocol/session/coordinator.rs)）。
+
+```typescript
+// lib/call-display.ts（変更後）
+
+export type DisplayStatus =
+  | "通話中"
+  | "常時着信拒否"
+  | "不在着信"
+  | "IVR離脱"
+  | "留守電"
+  | "通話終了"
+  | "応答なし"    // 追加（発信時に相手が応答しなかった場合）
+
+export function resolveDisplayStatus(call: Call): DisplayStatus {
+  // 0. 通話中
+  if (call.status === "ringing" || call.status === "in_call") return "通話中"
+
+  // 1-2. 発信通話（direction フィールドで判定。actionCode には依存しない）
+  // answeredAt は発信時 None 固定のため transferAnsweredAt（B-leg 応答時刻）を使用
+  if (call.direction === "outbound") {
+    return call.transferAnsweredAt !== null ? "通話終了" : "応答なし"
+  }
+
+  // 3-10. 着信通話（STEER-270 §5.2 と同じ、変更なし）
+  if (call.callDisposition === "denied") return "常時着信拒否"
+  // ...（省略、以降は STEER-270 の実装と同じ）
+}
+```
+
+### 5.11 フロントエンド: displayStatusClass の追加エントリ
+
+| displayStatus | スタイル |
+|---------------|---------|
+| 応答なし | `bg-orange-500/15 text-orange-600 dark:text-orange-300` |
+
+### 5.12 フロントエンド: calls-table.tsx の発信時表示
+
+| 列 | 着信時 | 発信時 |
+|----|--------|--------|
+| 方向 | 着信バッジ（着信, PhoneIncoming, primary 色） | 発信バッジ（発信, PhoneOutgoing, emerald 色）※既実装 |
+| 発信者 | callerNumber / fromName（外部発信者） | callerNumber（登録 SIP ユーザー番号）/ fromName は `"-"` |
+| 着信先 | `call.to`（システム番号） | `call.calleeNumber`（発信先番号）|
+| 着信応答 | callDisposition ラベル | `"-"`（発信通話では callDisposition は常に "allowed" だが表示は意味を持たないため非表示）|
+| IVR詳細 | actionCode に応じた詳細 | `"-"` |
+
+> **OQ-2 解決済み**: 発信時の `fromName` は `"-"` を表示する。現行 `fromName` は `callerCategory` ラベル由来であり、着信専用（外部発信者の種別）のため、発信通話には適用できない（[call-history-content.tsx:198](../../virtual-voicebot-frontend/components/call-history-content.tsx)）。
+
+> **OQ-4 解決済み**: 発信通話の `callDisposition` は通常ケースで `"allowed"` が設定される（BZ/RJ/AN=denied, NR=no_answer, それ以外=allowed）。発信では着信拒否・不在の概念が当てはまらないため、UI 表示は `"-"` とする（[coordinator.rs:860](../../virtual-voicebot-backend/src/protocol/session/coordinator.rs)）。
+
+```typescript
+// components/calls/calls-table.tsx（発信時の着信応答・IVR詳細）
+
+// 着信応答列
+{call.direction === "outbound" ? "-" : dispositionLabel(call.callDisposition)}
+
+// IVR詳細列
+{call.direction === "outbound" ? "-" : ivrDetailLabel(call.actionCode)}
+
+// 着信先列
+{call.direction === "outbound" ? call.calleeNumber ?? "-" : call.to}
+```
+
+### 5.13 フロントエンド: call-detail-drawer.tsx の発信時表示
+
+call-detail-drawer でも同様に、発信通話は以下の列/項目を `-` 表示にする：
+- 着信応答（callDisposition）
+- IVR詳細（actionCode 詳細パネル）
+
+着信先は `call.calleeNumber` を使用する。
+
+### 5.14 フロントエンド: CSV エクスポート
+
+```typescript
+// components/call-history-content.tsx（handleExportCSV）
+
+// 方向列
+call.direction === "outbound" ? "発信" : call.direction === "missed" ? "不在" : "着信"
+```
+
+---
+
+## 6. トレーサビリティ
+
+| From | To | 関係 |
+|------|-----|------|
+| Issue #275 | STEER-275 | 起票 |
+| Issue #272 / STEER-272 | STEER-275 | 前提（発着信バックエンド実装） |
+| STEER-275 | RD-001 F-13 | 要件補足（direction / calleeNumber の API 返却） |
+| STEER-275 | RD-005 §3.3 | 要件修正（発信時表示列定義追加） |
+| STEER-275 | `migrations/...` | DB スキーマ追加 |
+| STEER-275 | `src/shared/ports/call_log_port.rs` | EndedCallLog 拡張 |
+| STEER-275 | `src/interface/db/postgres.rs` | API レスポンス拡張 |
+| STEER-275 | `lib/db/sync.ts` (StoredCallLog + normalizeCallLog) | 取り込み層: direction / calleeNumber パース追加 |
+| STEER-275 | `lib/api.ts` (mapStoredCallToCall) | マッピング層: direction / calleeNumber 通過 |
+| STEER-275 | `lib/db/queries.ts` (deriveDirection) | フィルタ層: direction フィールド優先判定 |
+| STEER-275 | `lib/types.ts` | Call インターフェース拡張 |
+| STEER-275 | `lib/call-display.ts` | resolveDisplayStatus 発信分岐追加（transferAnsweredAt 判定）|
+| STEER-275 | `components/call-history-content.tsx` | toDirection / toRecord 修正 |
+| STEER-275 | `components/calls/calls-table.tsx` | 発信時表示修正 |
+| STEER-275 | `components/calls/call-detail-drawer.tsx` | 発信時表示修正 |
+| STEER-270 | STEER-275 | displayStatus 定義の拡張（発信分岐追加） |
+
+---
+
+## 7. レビューチェックリスト
+
+### 7.1 仕様レビュー（Review → Approved）
+
+- [ ] `direction` カラムの DEFAULT 'inbound' による既存レコードへの影響が問題ないか
+- [ ] 発信通話で `callee_number` をどのタイミング・どのコードパスで設定するか確認済みか（§5.3 参照）
+- [x] OQ-1（「応答なし」vs「不在着信」）→ **解決済み**（新規「応答なし」を追加）
+- [x] OQ-2（発信時の fromName 表示）→ **解決済み**（`"-"` を表示）
+- [x] OQ-3（発信時の actionCode: 何が設定されるか）→ **解決済み**（ルーティング評価結果が入る。direction フィールドで判定する）
+- [x] OQ-4（発信通話の callDisposition）→ **解決済み**（通常ケース "allowed"、UI 表示は "-"）
+- [x] OQ-5（callee_number の定義）→ **解決済み**（resolve_number() 解決後の番号）
+- [ ] `toDirection()` 変更後、既存の 着信通話の方向表示がデグレしないか（status=error/rejected の missed 判定は引き続き有効か）
+- [ ] 発信フィルタ（filter-bar）が `direction === "outbound"` に正しく反応するか確認済みか
+- [ ] `DisplayStatus "応答なし"` の displayStatusClass（orange）が STEER-270 のカラーパレットと整合しているか
+
+### 7.2 マージ前チェック（Approved → Merged）
+
+- [ ] DB マイグレーションが適用済み
+- [ ] バックエンドの実装完了（direction / callee_number の設定 + API 返却）
+- [ ] フロントエンドの実装完了（全 AC が満たされていること）
+- [ ] `resolveDisplayStatus` の単体テスト（発信分岐）が PASS（テスト観点: 下記参照）
+- [ ] 既存の着信通話表示がデグレしていない（回帰テスト）
+- [ ] コードレビュー（CodeRabbit）が完了している
+- [ ] RD-001 F-13 および RD-005 §3.3 への反映準備ができている
+
+#### テスト観点（最低限カバーすること）
+
+| # | テスト対象 | 入力 | 期待結果 |
+|---|-----------|------|---------|
+| T-01 | `resolveDisplayStatus` | direction=outbound, transferAnsweredAt=非null | 通話終了 |
+| T-02 | `resolveDisplayStatus` | direction=outbound, transferAnsweredAt=null | 応答なし |
+| T-03 | `resolveDisplayStatus` | direction=inbound, actionCode=IV, transferStatus=no_transfer | IVR離脱（デグレ確認）|
+| T-04 | `deriveDirection` | StoredCallLog.direction="outbound" | outbound |
+| T-05 | `deriveDirection` | StoredCallLog.direction="inbound", status=error | missed |
+| T-06 | `normalizeCallLog` | payload に direction="outbound", calleeNumber="09012345678" | StoredCallLog に正しく格納 |
+| T-07 | `normalizeCallLog` | payload に direction/calleeNumber なし | direction="inbound", calleeNumber=null（fallback）|
+| T-08 | filter-bar 発信フィルタ | direction=outbound のレコードのみ存在 | 1件ヒット（「発信」選択時）|
+| T-09 | calls-table 着信先列 | direction=outbound, calleeNumber="09099998888" | "09099998888" 表示 |
+| T-10 | calls-table 着信先列 | direction=outbound, calleeNumber=null | "-" 表示 |
+| T-11 | calls-table 着信応答列 | direction=outbound | "-" 表示 |
+| T-12 | CSV エクスポート | direction=outbound | 方向列に "発信" |
+
+---
+
+## 8. Open Questions
+
+| # | 質問 | 解決方針 | 合意状況 |
+|---|------|---------|---------|
+| OQ-1 | 発信時に相手が応答しなかった場合の displayStatus は新規「応答なし」か、既存「不在着信」を転用するか？ | 新規「応答なし」を追加する。着信の「不在着信」（相手に出てもらえなかった）と発信の「応答なし」（かけた先が出なかった）は意味が異なるため混用しない。 | **解決済み** |
+| OQ-2 | 発信時の 発信者列（fromName）は何を表示するか？ | `fromName` は `"-"` を表示する。現行 `fromName` は着信専用の `callerCategory` ラベル由来のため発信には不適。主表示は `callerNumber`（登録 SIP ユーザー番号）のみ。 | **解決済み** |
+| OQ-3 | 発信通話（STEER-272 の B2BUA 転送）では `actionCode` に何が設定されるか？ | 発信専用コードは設定されない。ルーティングルール評価結果（主に VR / IV 等）が入る。`"AR"` は Backend が実際にセットしていないため、フロントエンドの発信判定は必ず `direction` フィールドを使用すること。 | **解決済み** |
+| OQ-4 | 発信通話の `callDisposition` には何が設定されるか？ | 通常ケースでは `"allowed"`（BZ/RJ/AN=denied, NR=no_answer, それ以外=allowed）。UI 表示は発信では意味を持たないため `"-"` を表示する。 | **解決済み** |
+| OQ-5 | `callee_number` は SIP To URI のユーザー部（生の電話番号）か、ダイヤルプランで解決後の番号か？ | `resolve_number()` 解決後の番号（実際に `sip:{number}@{outbound_domain}` として発呼した番号）を採用する。 | **解決済み** |
+
+---
+
+## 9. 備考
+
+- **STEER-270 との関係**: STEER-270 の §9 備考に「`AR`（発信コール）の displayStatus は本 Issue では未定義（Fallback → 通話終了）。発信通話の履歴改善は別 Issue で検討予定」とあり、本 STEER-275 がその別 Issue に該当する。
+- **STEER-272 との関係**: STEER-272 でバックエンドの発着信同時サポートが実装されたが、`direction` / `callee_number` の API 露出は本ステアリングのスコープ。RD-001 F-13 の補足として追記する。
+- **actionCode の扱い（OQ-3 より）**: バックエンドは発信通話に `"AR"` をセットしていない。`actionCode` には着信と同じルーティング評価結果（VR / IV 等）が入るため、`resolveDisplayStatus` の発信通話分岐は `direction === "outbound"` チェックを actionCode ベース分岐より前に評価することで、誤分類（例: outbound + IV が「IVR離脱」になる）を防ぐ。
+- **callerNumber の意味（発信時）**: 着信時は外部発信者番号だが、発信時は登録 SIP ユーザー番号（REGISTER_USER）が入る。表示上は同じフィールドを流用するが、列ラベル「発信者」はどちらの場合も文脈的に成立する（着信時: 誰が発信してきたか、発信時: 誰が発信したか）。
+- **fromName = "-" の根拠（OQ-2 より）**: 現行 `fromName` は `callerCategory`（"未登録" / "登録済み" 等）ラベルであり、発信通話では `callerCategory` を発信者種別として使用しないため `"-"` が適切。
+- **503 拒否の known limitation**: `is_outbound_intent = true` だが config 不備（domain 未設定 / dial plan 未解決）で 503 を返した通話は、`outbound_mode = false` のまま ingest されるため、履歴上は `direction = "inbound"` として記録される（[handlers/mod.rs:124-139](../../virtual-voicebot-backend/src/protocol/session/handlers/mod.rs)）。この通話は実態と異なる「着信」として表示されるが、config 不備による異常系であり、本スコープでは許容する。
+- **answeredAt の現状（重大指摘2 対応）**: Backend の `answered_at` は発信通話で `None` 固定（[coordinator.rs:821](../../virtual-voicebot-backend/src/protocol/session/coordinator.rs)）。発信通話の「通話終了 / 応答なし」判定には B-leg 応答時刻 `transferAnsweredAt` を使用する（§5.10 参照）。将来 `answered_at` の保存が追加された場合は判定軸の見直しが必要。
+
+---
+
+## 変更履歴
+
+| 日付 | 変更内容 | 作成者 |
+|------|---------|--------|
+| 2026-03-02 | 初版作成 | Claude Code (claude-sonnet-4-6) |
+| 2026-03-02 | OQ-1〜5 全解決済みに更新（応答なし追加確定・fromName="-"確定・actionCode非依存設計確定・callee_number=resolve後番号確定） | Claude Code (claude-sonnet-4-6) |
+| 2026-03-02 | レビュー指摘対応（重大3件・中3件）: sync.ts/api.ts/queries.ts を影響範囲追加、answeredAt→transferAnsweredAt 変更、503 known limitation 追記、AC-6 参照節修正、相対パス修正、テスト観点12件追加 | Claude Code (claude-sonnet-4-6) |
+| 2026-03-02 | レビュー指摘対応（中1件・軽1件）: §5.7→§5.10 参照修正（AC-6・§4.2）、章番号欠番（5.10 空き）を解消（5.11〜5.15 → 5.10〜5.14 繰り上げ） | Claude Code (claude-sonnet-4-6) |
+| 2026-03-02 | レビュー OK（新規指摘なし）。残リスク: 503 異常系 known limitation・answered_at 将来見直し（§9 明示済み） | @MasanoriSuda (via Claude Code) |

--- a/docs/steering/index.md
+++ b/docs/steering/index.md
@@ -52,6 +52,7 @@ STEER-{イシュー番号}_{slug}.md
 | [STEER-245](STEER-245_local-services-status-dashboard.md) | ローカルサービス死活監視ダッシュボード | Approved | #245 | P1 | Frontend のダッシュボードに ASR/LLM/TTS ローカルサービスの死活状態を表示する。Backend が probe を集約し、Frontend はウィジェットで可視化する |
 | [STEER-266](STEER-266_incoming-call-popup.md) | 着信ポップアップ通知 | Draft | #266 | P1 | 着信（直接転送・IVR 転送）を契機に Frontend 画面上でポップアップを表示する。独立 fast-path ファイルキュー + serversync 新規 Worker（1秒ポーリング）で既存 sync_outbox に影響なく実装する |
 | [STEER-267](STEER-267_ivr-vr-notify-fix.md) | DB IVR VR ルートの転送通知欠落バグ修正 | Approved | #267 | P1 | STEER-266 実装後に発覚した仕様漏れ。DB IVR の `"VR" =>` ルート（handlers/mod.rs L1304）に `notify_ivr_transfer_if_needed()` 呼び出しが欠落しており、IVR 転送時にポップアップが発火しない |
+| [STEER-275](STEER-275_outbound-call-history-display.md) | フロントエンド発着信履歴の発信時表示修正 | Draft | #275 | P1 | #272 発着信バックエンド実装後、発信通話が履歴画面で「着信」と表示される問題を修正。Backend API に direction / calleeNumber を追加し、Frontend の発信時表示列を正しく定義する |
 
 ---
 
@@ -93,3 +94,4 @@ STEER-{イシュー番号}_{slug}.md
 | 2026-02-25 | 1.2 | STEER-245 ステータス Draft → Approved | @MasanoriSuda |
 | 2026-02-28 | 1.3 | STEER-266 追加（着信ポップアップ通知） | Claude Sonnet 4.6 |
 | 2026-02-28 | 1.4 | STEER-267 追加（DB IVR VR ルート転送通知欠落バグ修正） | Claude Sonnet 4.6 |
+| 2026-03-02 | 1.5 | STEER-275 追加（フロントエンド発着信履歴の発信時表示修正） | Claude Sonnet 4.6 |

--- a/virtual-voicebot-backend/migrations/20260302000001_add_direction_callee_number_to_call_logs.sql
+++ b/virtual-voicebot-backend/migrations/20260302000001_add_direction_callee_number_to_call_logs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE call_logs
+    ADD COLUMN direction TEXT NOT NULL DEFAULT 'inbound'
+        CHECK (direction IN ('inbound', 'outbound')),
+    ADD COLUMN callee_number TEXT;

--- a/virtual-voicebot-backend/src/interface/db/postgres.rs
+++ b/virtual-voicebot-backend/src/interface/db/postgres.rs
@@ -38,6 +38,15 @@ use crate::shared::ports::sync_outbox_port::{
 
 const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(3);
 const MAX_CONNECTIONS: u32 = 5;
+const INSERT_CALL_LOG_SQL: &str = "INSERT INTO call_logs (
+                    id, started_at, external_call_id, sip_call_id, caller_number, caller_category,
+                    direction, callee_number, action_code, ivr_flow_id, answered_at, ended_at, duration_sec, end_reason, status,
+                    call_disposition, final_action, transfer_status,
+                    transfer_started_at, transfer_answered_at, transfer_ended_at
+                 ) VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                    $14, $15, $16, $17, $18, $19, $20, $21
+                 )";
 
 pub struct PostgresAdapter {
     pool: PgPool,
@@ -727,6 +736,31 @@ impl PostgresAdapter {
     }
 }
 
+fn build_call_log_sync_payload(call_log: &EndedCallLog) -> Value {
+    json!({
+        "id": call_log.id.to_string(),
+        "externalCallId": call_log.external_call_id.clone(),
+        "sipCallId": call_log.sip_call_id.clone(),
+        "callerNumber": call_log.caller_number.clone(),
+        "direction": call_log.direction.clone(),
+        "calleeNumber": call_log.callee_number.clone(),
+        "callerCategory": call_log.caller_category.clone(),
+        "actionCode": call_log.action_code.clone(),
+        "startedAt": call_log.started_at.to_rfc3339(),
+        "answeredAt": call_log.answered_at.as_ref().map(DateTime::to_rfc3339),
+        "endedAt": call_log.ended_at.to_rfc3339(),
+        "durationSec": call_log.duration_sec,
+        "endReason": call_log.end_reason.clone(),
+        "status": call_log.status.clone(),
+        "callDisposition": call_log.call_disposition.clone(),
+        "finalAction": call_log.final_action.clone(),
+        "transferStatus": call_log.transfer_status.clone(),
+        "transferStartedAt": call_log.transfer_started_at.as_ref().map(DateTime::to_rfc3339),
+        "transferAnsweredAt": call_log.transfer_answered_at.as_ref().map(DateTime::to_rfc3339),
+        "transferEndedAt": call_log.transfer_ended_at.as_ref().map(DateTime::to_rfc3339),
+    })
+}
+
 impl PhoneLookupPort for PostgresAdapter {
     fn lookup_phone(&self, phone_number: String) -> PhoneLookupFuture {
         let pool = self.pool.clone();
@@ -747,41 +781,31 @@ impl CallLogPort for PostgresAdapter {
                 .await
                 .map_err(map_call_log_write_err)?;
 
-            sqlx::query(
-                "INSERT INTO call_logs (
-                    id, started_at, external_call_id, sip_call_id, caller_number, caller_category,
-                    direction, callee_number, action_code, ivr_flow_id, answered_at, ended_at, duration_sec, end_reason, status,
-                    call_disposition, final_action, transfer_status,
-                    transfer_started_at, transfer_answered_at, transfer_ended_at
-                 ) VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-                    $14, $15, $16, $17, $18, $19, $20, $21
-                 )",
-            )
-            .bind(call_log.id)
-            .bind(call_log.started_at)
-            .bind(call_log.external_call_id.clone())
-            .bind(Some(call_log.sip_call_id.clone()))
-            .bind(call_log.caller_number.clone())
-            .bind(call_log.caller_category.clone())
-            .bind(call_log.direction.clone())
-            .bind(call_log.callee_number.clone())
-            .bind(call_log.action_code.clone())
-            .bind(call_log.ivr_flow_id)
-            .bind(call_log.answered_at)
-            .bind(call_log.ended_at)
-            .bind(call_log.duration_sec)
-            .bind(call_log.end_reason.clone())
-            .bind(call_log.status.clone())
-            .bind(call_log.call_disposition.clone())
-            .bind(call_log.final_action.clone())
-            .bind(call_log.transfer_status.clone())
-            .bind(call_log.transfer_started_at)
-            .bind(call_log.transfer_answered_at)
-            .bind(call_log.transfer_ended_at)
-            .execute(&mut *tx)
-            .await
-            .map_err(map_call_log_write_err)?;
+            sqlx::query(INSERT_CALL_LOG_SQL)
+                .bind(call_log.id)
+                .bind(call_log.started_at)
+                .bind(call_log.external_call_id.clone())
+                .bind(Some(call_log.sip_call_id.clone()))
+                .bind(call_log.caller_number.clone())
+                .bind(call_log.caller_category.clone())
+                .bind(call_log.direction.clone())
+                .bind(call_log.callee_number.clone())
+                .bind(call_log.action_code.clone())
+                .bind(call_log.ivr_flow_id)
+                .bind(call_log.answered_at)
+                .bind(call_log.ended_at)
+                .bind(call_log.duration_sec)
+                .bind(call_log.end_reason.clone())
+                .bind(call_log.status.clone())
+                .bind(call_log.call_disposition.clone())
+                .bind(call_log.final_action.clone())
+                .bind(call_log.transfer_status.clone())
+                .bind(call_log.transfer_started_at)
+                .bind(call_log.transfer_answered_at)
+                .bind(call_log.transfer_ended_at)
+                .execute(&mut *tx)
+                .await
+                .map_err(map_call_log_write_err)?;
 
             sqlx::query(
                 "INSERT INTO sync_outbox (entity_type, entity_id, payload)
@@ -789,28 +813,7 @@ impl CallLogPort for PostgresAdapter {
             )
             .bind("call_log")
             .bind(call_log.id)
-            .bind(json!({
-                "id": call_log.id.to_string(),
-                "externalCallId": call_log.external_call_id.clone(),
-                "sipCallId": call_log.sip_call_id.clone(),
-                "callerNumber": call_log.caller_number.clone(),
-                "direction": call_log.direction.clone(),
-                "calleeNumber": call_log.callee_number.clone(),
-                "callerCategory": call_log.caller_category.clone(),
-                "actionCode": call_log.action_code.clone(),
-                "startedAt": call_log.started_at.to_rfc3339(),
-                "answeredAt": call_log.answered_at.as_ref().map(DateTime::to_rfc3339),
-                "endedAt": call_log.ended_at.to_rfc3339(),
-                "durationSec": call_log.duration_sec,
-                "endReason": call_log.end_reason.clone(),
-                "status": call_log.status.clone(),
-                "callDisposition": call_log.call_disposition.clone(),
-                "finalAction": call_log.final_action.clone(),
-                "transferStatus": call_log.transfer_status.clone(),
-                "transferStartedAt": call_log.transfer_started_at.as_ref().map(DateTime::to_rfc3339),
-                "transferAnsweredAt": call_log.transfer_answered_at.as_ref().map(DateTime::to_rfc3339),
-                "transferEndedAt": call_log.transfer_ended_at.as_ref().map(DateTime::to_rfc3339),
-            }))
+            .bind(build_call_log_sync_payload(&call_log))
             .execute(&mut *tx)
             .await
             .map_err(map_call_log_write_err)?;
@@ -1217,4 +1220,65 @@ fn map_sync_outbox_write_err(
     err: sqlx::Error,
 ) -> crate::shared::ports::sync_outbox_port::SyncOutboxError {
     crate::shared::ports::sync_outbox_port::SyncOutboxError::WriteFailed(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn sample_ended_call_log() -> EndedCallLog {
+        let now = Utc::now();
+        EndedCallLog {
+            id: Uuid::now_v7(),
+            started_at: now,
+            ended_at: now,
+            duration_sec: Some(10),
+            external_call_id: "external-1".to_string(),
+            sip_call_id: "sip-1".to_string(),
+            caller_number: Some("+819011112222".to_string()),
+            direction: "outbound".to_string(),
+            callee_number: Some("09012345678".to_string()),
+            caller_category: "registered".to_string(),
+            action_code: "VR".to_string(),
+            ivr_flow_id: None,
+            answered_at: None,
+            end_reason: "normal".to_string(),
+            status: "ended".to_string(),
+            call_disposition: "allowed".to_string(),
+            final_action: Some("normal_call".to_string()),
+            transfer_status: "answered".to_string(),
+            transfer_started_at: None,
+            transfer_answered_at: None,
+            transfer_ended_at: None,
+            ivr_events: Vec::new(),
+            recording: None,
+        }
+    }
+
+    #[test]
+    fn persist_call_ended_insert_sql_has_direction_and_callee_number_columns() {
+        assert!(INSERT_CALL_LOG_SQL.contains("direction, callee_number"));
+    }
+
+    #[test]
+    fn call_log_sync_payload_includes_direction_and_callee_number() {
+        let call_log = sample_ended_call_log();
+        let payload = build_call_log_sync_payload(&call_log);
+
+        assert_eq!(payload["direction"], "outbound");
+        assert_eq!(payload["calleeNumber"], "09012345678");
+    }
+
+    #[test]
+    fn call_log_sync_payload_sets_null_callee_number_for_inbound() {
+        let mut call_log = sample_ended_call_log();
+        call_log.direction = "inbound".to_string();
+        call_log.callee_number = None;
+        let payload = build_call_log_sync_payload(&call_log);
+
+        assert_eq!(payload["direction"], "inbound");
+        assert!(payload["calleeNumber"].is_null());
+    }
 }

--- a/virtual-voicebot-backend/src/interface/db/postgres.rs
+++ b/virtual-voicebot-backend/src/interface/db/postgres.rs
@@ -750,12 +750,12 @@ impl CallLogPort for PostgresAdapter {
             sqlx::query(
                 "INSERT INTO call_logs (
                     id, started_at, external_call_id, sip_call_id, caller_number, caller_category,
-                    action_code, ivr_flow_id, answered_at, ended_at, duration_sec, end_reason, status,
+                    direction, callee_number, action_code, ivr_flow_id, answered_at, ended_at, duration_sec, end_reason, status,
                     call_disposition, final_action, transfer_status,
                     transfer_started_at, transfer_answered_at, transfer_ended_at
                  ) VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-                    $14, $15, $16, $17, $18, $19
+                    $14, $15, $16, $17, $18, $19, $20, $21
                  )",
             )
             .bind(call_log.id)
@@ -764,6 +764,8 @@ impl CallLogPort for PostgresAdapter {
             .bind(Some(call_log.sip_call_id.clone()))
             .bind(call_log.caller_number.clone())
             .bind(call_log.caller_category.clone())
+            .bind(call_log.direction.clone())
+            .bind(call_log.callee_number.clone())
             .bind(call_log.action_code.clone())
             .bind(call_log.ivr_flow_id)
             .bind(call_log.answered_at)
@@ -792,6 +794,8 @@ impl CallLogPort for PostgresAdapter {
                 "externalCallId": call_log.external_call_id.clone(),
                 "sipCallId": call_log.sip_call_id.clone(),
                 "callerNumber": call_log.caller_number.clone(),
+                "direction": call_log.direction.clone(),
+                "calleeNumber": call_log.callee_number.clone(),
                 "callerCategory": call_log.caller_category.clone(),
                 "actionCode": call_log.action_code.clone(),
                 "startedAt": call_log.started_at.to_rfc3339(),

--- a/virtual-voicebot-backend/src/interface/db/postgres.rs
+++ b/virtual-voicebot-backend/src/interface/db/postgres.rs
@@ -741,6 +741,8 @@ fn build_call_log_sync_payload(call_log: &EndedCallLog) -> Value {
         "id": call_log.id.to_string(),
         "externalCallId": call_log.external_call_id.clone(),
         "sipCallId": call_log.sip_call_id.clone(),
+        // Keep MVP traceability by mirroring session identifier as call_id.
+        "call_id": call_log.sip_call_id.clone(),
         "callerNumber": call_log.caller_number.clone(),
         "direction": call_log.direction.clone(),
         "calleeNumber": call_log.callee_number.clone(),
@@ -1267,6 +1269,7 @@ mod tests {
         let call_log = sample_ended_call_log();
         let payload = build_call_log_sync_payload(&call_log);
 
+        assert_eq!(payload["call_id"], "sip-1");
         assert_eq!(payload["direction"], "outbound");
         assert_eq!(payload["calleeNumber"], "09012345678");
     }

--- a/virtual-voicebot-backend/src/protocol/session/coordinator.rs
+++ b/virtual-voicebot-backend/src/protocol/session/coordinator.rs
@@ -967,8 +967,18 @@ mod tests {
     impl CallLogPort for DummyCallLogPort {
         fn persist_call_ended(
             &self,
-            _call_log: EndedCallLog,
+            call_log: EndedCallLog,
         ) -> crate::shared::ports::call_log_port::CallLogFuture<()> {
+            assert!(
+                matches!(call_log.direction.as_str(), "inbound" | "outbound"),
+                "direction must be inbound/outbound"
+            );
+            if call_log.direction == "inbound" {
+                assert!(
+                    call_log.callee_number.is_none(),
+                    "inbound call log must not carry callee_number"
+                );
+            }
             Box::pin(async { Ok(()) })
         }
     }
@@ -977,6 +987,8 @@ mod tests {
     struct FailingThenSucceedingState {
         attempts: usize,
         ivr_event_counts: Vec<usize>,
+        directions: Vec<String>,
+        callee_numbers: Vec<Option<String>>,
     }
 
     struct FailingThenSucceedingCallLogPort {
@@ -999,6 +1011,8 @@ mod tests {
                 let mut guard = state.lock().expect("state lock should be available");
                 guard.attempts += 1;
                 guard.ivr_event_counts.push(call_log.ivr_events.len());
+                guard.directions.push(call_log.direction.clone());
+                guard.callee_numbers.push(call_log.callee_number.clone());
                 if guard.attempts == 1 {
                     return Err(CallLogPortError::WriteFailed(
                         "simulated transient failure".into(),
@@ -1476,6 +1490,11 @@ mod tests {
         let guard = state.lock().expect("state lock should be available");
         assert_eq!(guard.attempts, 2);
         assert_eq!(guard.ivr_event_counts, vec![1, 1]);
+        assert_eq!(
+            guard.directions,
+            vec!["inbound".to_string(), "inbound".to_string()]
+        );
+        assert_eq!(guard.callee_numbers, vec![None, None]);
     }
 
     #[tokio::test]

--- a/virtual-voicebot-backend/src/protocol/session/coordinator.rs
+++ b/virtual-voicebot-backend/src/protocol/session/coordinator.rs
@@ -753,8 +753,12 @@ impl SessionCoordinator {
         let call_log_id = self.ensure_call_log_id();
         let caller_number = extract_e164_caller_number(self.from_uri.as_str());
         let (direction, callee_number) = if self.outbound_mode {
-            let callee_number = extract_user_from_to(self.to_uri.as_str())
-                .and_then(|to_user| self.runtime_cfg.outbound.resolve_number(to_user.as_str()));
+            let callee_number = extract_user_from_to(self.to_uri.as_str()).map(|to_user| {
+                self.runtime_cfg
+                    .outbound
+                    .resolve_number(to_user.as_str())
+                    .unwrap_or(to_user)
+            });
             ("outbound".to_string(), callee_number)
         } else {
             ("inbound".to_string(), None)
@@ -1532,6 +1536,28 @@ mod tests {
             guard.calls[0].callee_number,
             Some("09012345678".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn send_ingest_persists_outbound_callee_number_from_to_user_when_resolve_fails() {
+        let mut session = build_test_session(Arc::new(DummyStoragePort));
+        let state = Arc::new(Mutex::new(CapturingCallLogState::default()));
+        session.call_log_port = Arc::new(CapturingCallLogPort::new(state.clone()));
+        session.initial_action_code = Some("VR".to_string());
+        session.outbound_mode = true;
+        session.to_uri = "sip:alice@example.com".to_string();
+
+        let mut runtime_cfg = (*session.runtime_cfg).clone();
+        runtime_cfg.outbound.default_number = None;
+        runtime_cfg.outbound.dial_plan.clear();
+        session.runtime_cfg = Arc::new(runtime_cfg);
+
+        session.send_ingest("ended").await;
+
+        let guard = state.lock().expect("state lock should be available");
+        assert_eq!(guard.calls.len(), 1);
+        assert_eq!(guard.calls[0].direction, "outbound");
+        assert_eq!(guard.calls[0].callee_number, Some("alice".to_string()));
     }
 
     #[test]

--- a/virtual-voicebot-backend/src/protocol/session/coordinator.rs
+++ b/virtual-voicebot-backend/src/protocol/session/coordinator.rs
@@ -752,6 +752,13 @@ impl SessionCoordinator {
             .map(|s| s.elapsed().as_secs().min(i32::MAX as u64) as i32);
         let call_log_id = self.ensure_call_log_id();
         let caller_number = extract_e164_caller_number(self.from_uri.as_str());
+        let (direction, callee_number) = if self.outbound_mode {
+            let callee_number = extract_user_from_to(self.to_uri.as_str())
+                .and_then(|to_user| self.runtime_cfg.outbound.resolve_number(to_user.as_str()));
+            ("outbound".to_string(), callee_number)
+        } else {
+            ("inbound".to_string(), None)
+        };
         let action_code = self
             .initial_action_code
             .as_deref()
@@ -815,6 +822,8 @@ impl SessionCoordinator {
             external_call_id: call_log_id.to_string(),
             sip_call_id: self.call_id.to_string(),
             caller_number,
+            direction,
+            callee_number,
             caller_category: self.caller_category.clone(),
             action_code,
             ivr_flow_id: self.ivr_flow_id,
@@ -995,6 +1004,35 @@ mod tests {
                         "simulated transient failure".into(),
                     ));
                 }
+                Ok(())
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturingCallLogState {
+        calls: Vec<EndedCallLog>,
+    }
+
+    struct CapturingCallLogPort {
+        state: Arc<Mutex<CapturingCallLogState>>,
+    }
+
+    impl CapturingCallLogPort {
+        fn new(state: Arc<Mutex<CapturingCallLogState>>) -> Self {
+            Self { state }
+        }
+    }
+
+    impl CallLogPort for CapturingCallLogPort {
+        fn persist_call_ended(
+            &self,
+            call_log: EndedCallLog,
+        ) -> crate::shared::ports::call_log_port::CallLogFuture<()> {
+            let state = self.state.clone();
+            Box::pin(async move {
+                let mut guard = state.lock().expect("state lock should be available");
+                guard.calls.push(call_log);
                 Ok(())
             })
         }
@@ -1438,6 +1476,43 @@ mod tests {
         let guard = state.lock().expect("state lock should be available");
         assert_eq!(guard.attempts, 2);
         assert_eq!(guard.ivr_event_counts, vec![1, 1]);
+    }
+
+    #[tokio::test]
+    async fn send_ingest_persists_inbound_direction_without_callee_number() {
+        let mut session = build_test_session(Arc::new(DummyStoragePort));
+        let state = Arc::new(Mutex::new(CapturingCallLogState::default()));
+        session.call_log_port = Arc::new(CapturingCallLogPort::new(state.clone()));
+        session.initial_action_code = Some("VR".to_string());
+        session.outbound_mode = false;
+        session.to_uri = "sip:09011112222@example.com".to_string();
+
+        session.send_ingest("ended").await;
+
+        let guard = state.lock().expect("state lock should be available");
+        assert_eq!(guard.calls.len(), 1);
+        assert_eq!(guard.calls[0].direction, "inbound");
+        assert_eq!(guard.calls[0].callee_number, None);
+    }
+
+    #[tokio::test]
+    async fn send_ingest_persists_outbound_direction_and_resolved_callee_number() {
+        let mut session = build_test_session(Arc::new(DummyStoragePort));
+        let state = Arc::new(Mutex::new(CapturingCallLogState::default()));
+        session.call_log_port = Arc::new(CapturingCallLogPort::new(state.clone()));
+        session.initial_action_code = Some("VR".to_string());
+        session.outbound_mode = true;
+        session.to_uri = "sip:09012345678@example.com".to_string();
+
+        session.send_ingest("ended").await;
+
+        let guard = state.lock().expect("state lock should be available");
+        assert_eq!(guard.calls.len(), 1);
+        assert_eq!(guard.calls[0].direction, "outbound");
+        assert_eq!(
+            guard.calls[0].callee_number,
+            Some("09012345678".to_string())
+        );
     }
 
     #[test]

--- a/virtual-voicebot-backend/src/shared/ports/call_log_port.rs
+++ b/virtual-voicebot-backend/src/shared/ports/call_log_port.rs
@@ -26,6 +26,8 @@ pub struct EndedCallLog {
     pub external_call_id: String,
     pub sip_call_id: String,
     pub caller_number: Option<String>,
+    pub direction: String,
+    pub callee_number: Option<String>,
     pub caller_category: String,
     pub action_code: String,
     pub ivr_flow_id: Option<Uuid>,

--- a/virtual-voicebot-frontend/components/call-history-content.tsx
+++ b/virtual-voicebot-frontend/components/call-history-content.tsx
@@ -189,14 +189,16 @@ export function CallHistoryContent({ initialCalls }: CallHistoryContentProps) {
 function toRecord(call: Call): CallRecord {
   const status = toStatus(call.status)
   const direction = toDirection(call)
+  const isOutbound = direction === "outbound"
 
   return {
     id: call.id,
     callId: call.externalCallId,
     actionCode: call.actionCode,
     from: call.callerNumber ?? "非通知",
-    fromName: categoryLabel(call.callerCategory),
-    to: "未設定",
+    fromName: isOutbound ? "-" : categoryLabel(call.callerCategory),
+    to: isOutbound ? (call.calleeNumber ?? "-") : "未設定",
+    calleeNumber: call.calleeNumber ?? null,
     startedAt: call.startedAt,
     endedAt: call.endedAt ?? null,
     status,
@@ -226,8 +228,7 @@ function toStatus(status: Call["status"]): CallRecord["status"] {
 
 function toDirection(call: Call): CallRecord["direction"] {
   if (call.status === "error" || call.endReason === "rejected") return "missed"
-  if (call.actionCode === "AR") return "outbound"
-  return "inbound"
+  return call.direction
 }
 
 function categoryLabel(category: Call["callerCategory"]): string {

--- a/virtual-voicebot-frontend/components/calls/calls-table.tsx
+++ b/virtual-voicebot-frontend/components/calls/calls-table.tsx
@@ -82,8 +82,12 @@ export function CallsTable({ calls, sortDirection, onSortToggle, onRowClick }: C
                     <p className="text-xs text-muted-foreground">{call.from}</p>
                   </div>
                 </TableCell>
-                <TableCell className="text-sm">{call.to}</TableCell>
-                <TableCell className="text-sm">{dispositionLabel(call.callDisposition)}</TableCell>
+                <TableCell className="text-sm">
+                  {call.direction === "outbound" ? (call.calleeNumber ?? "-") : call.to}
+                </TableCell>
+                <TableCell className="text-sm">
+                  {call.direction === "outbound" ? "-" : dispositionLabel(call.callDisposition)}
+                </TableCell>
                 <TableCell className="text-sm">{finalActionLabel(call.finalAction)}</TableCell>
                 <TableCell className="text-sm">{transferStatusLabel(call.transferStatus)}</TableCell>
                 <TableCell className="font-mono text-xs">
@@ -95,7 +99,7 @@ export function CallsTable({ calls, sortDirection, onSortToggle, onRowClick }: C
                   </Badge>
                 </TableCell>
                 <TableCell className="text-sm">
-                  {call.actionCode === "IV" ? (
+                  {call.direction !== "outbound" && call.actionCode === "IV" ? (
                     <Link
                       href={`/calls/${encodeURIComponent(call.id)}/ivr-trace`}
                       className="text-primary underline-offset-2 hover:underline"

--- a/virtual-voicebot-frontend/lib/api.ts
+++ b/virtual-voicebot-frontend/lib/api.ts
@@ -55,11 +55,12 @@ function asISOString(value: string | null | undefined, fallback = new Date().toI
 }
 
 function mapStoredCallToCall(callLog: StoredCallLog): Call {
+  const isOutbound = callLog.direction === "outbound" || callLog.actionCode === "AR"
   return {
     id: callLog.id,
     externalCallId: callLog.externalCallId,
     callerNumber: callLog.callerNumber,
-    direction: callLog.direction === "outbound" ? "outbound" : "inbound",
+    direction: isOutbound ? "outbound" : "inbound",
     calleeNumber: callLog.calleeNumber ?? null,
     callerCategory: (callLog.callerCategory as Call["callerCategory"]) ?? "unknown",
     actionCode: (callLog.actionCode as Call["actionCode"]) ?? "IV",

--- a/virtual-voicebot-frontend/lib/api.ts
+++ b/virtual-voicebot-frontend/lib/api.ts
@@ -59,6 +59,8 @@ function mapStoredCallToCall(callLog: StoredCallLog): Call {
     id: callLog.id,
     externalCallId: callLog.externalCallId,
     callerNumber: callLog.callerNumber,
+    direction: callLog.direction === "outbound" ? "outbound" : "inbound",
+    calleeNumber: callLog.calleeNumber ?? null,
     callerCategory: (callLog.callerCategory as Call["callerCategory"]) ?? "unknown",
     actionCode: (callLog.actionCode as Call["actionCode"]) ?? "IV",
     status: (callLog.status as Call["status"]) ?? "ended",
@@ -160,7 +162,7 @@ function toMockCallDetail(call: Call): CallDetail {
   return {
     ...call,
     from: call.callerNumber ?? "非通知",
-    to: view?.to ?? "未設定",
+    to: call.direction === "outbound" ? (call.calleeNumber ?? "未設定") : (view?.to ?? "未設定"),
     startTime: call.startedAt,
     duration: call.durationSec ?? 0,
     summary: view?.summary ?? "",
@@ -239,7 +241,7 @@ export async function getCallDetail(callId: string): Promise<CallDetail | null> 
   return {
     ...call,
     from: call.callerNumber ?? "非通知",
-    to: "未設定",
+    to: call.direction === "outbound" ? (call.calleeNumber ?? "未設定") : "未設定",
     startTime: call.startedAt,
     duration: call.durationSec ?? 0,
     summary,

--- a/virtual-voicebot-frontend/lib/call-display.ts
+++ b/virtual-voicebot-frontend/lib/call-display.ts
@@ -4,12 +4,16 @@ export type DisplayStatus =
   | "通話中"
   | "常時着信拒否"
   | "不在着信"
+  | "応答なし"
   | "IVR離脱"
   | "留守電"
   | "通話終了"
 
 export function resolveDisplayStatus(call: Call): DisplayStatus {
   if (call.status === "ringing" || call.status === "in_call") return "通話中"
+  if (call.direction === "outbound") {
+    return call.transferAnsweredAt !== null ? "通話終了" : "応答なし"
+  }
   if (call.callDisposition === "denied") return "常時着信拒否"
   if (call.endReason === "cancelled" && call.answeredAt === null) return "不在着信"
 
@@ -43,6 +47,8 @@ export function displayStatusClass(status: DisplayStatus): string {
       return "bg-neutral-500/15 text-neutral-600 dark:text-neutral-300"
     case "不在着信":
       return "bg-rose-500/15 text-rose-600 dark:text-rose-300"
+    case "応答なし":
+      return "bg-orange-500/15 text-orange-600 dark:text-orange-300"
     case "IVR離脱":
       return "bg-amber-500/15 text-amber-600 dark:text-amber-300"
     case "留守電":

--- a/virtual-voicebot-frontend/lib/db/queries.ts
+++ b/virtual-voicebot-frontend/lib/db/queries.ts
@@ -31,7 +31,7 @@ export function deriveDirection(callLog: StoredCallLog): CallDirection {
   if (callLog.status === "error" || callLog.endReason === "rejected") {
     return "missed"
   }
-  if (callLog.actionCode === "AR") {
+  if (callLog.direction === "outbound" || callLog.actionCode === "AR") {
     return "outbound"
   }
   return "inbound"
@@ -57,7 +57,12 @@ export async function queryCalls(filters: CallQueryFilters = {}): Promise<QueryC
         return false
       }
       if (keyword) {
-        const target = [callLog.externalCallId, callLog.sipCallId, callLog.callerNumber]
+        const target = [
+          callLog.externalCallId,
+          callLog.sipCallId,
+          callLog.callerNumber,
+          callLog.calleeNumber,
+        ]
           .filter(Boolean)
           .join(" ")
           .toLowerCase()

--- a/virtual-voicebot-frontend/lib/db/sync.ts
+++ b/virtual-voicebot-frontend/lib/db/sync.ts
@@ -193,10 +193,15 @@ function asIsoDate(
   return fallback
 }
 
+function normalizeDirection(value: string | null): "inbound" | "outbound" {
+  const normalized = (value ?? "").trim().toLowerCase()
+  return normalized === "outbound" ? "outbound" : "inbound"
+}
+
 function normalizeCallLog(entityId: string, payload: unknown, nowIso: string): StoredCallLog {
   const input = isRecord(payload) ? payload : {}
   const id = asString(input, ["id"], entityId) ?? entityId
-  const direction = asString(input, ["direction"], "inbound")
+  const direction = normalizeDirection(asString(input, ["direction"], "inbound"))
   const calleeNumberRaw = asString(input, ["calleeNumber", "callee_number"], null)
   const calleeNumber =
     typeof calleeNumberRaw === "string" && calleeNumberRaw.trim().length === 0
@@ -207,7 +212,7 @@ function normalizeCallLog(entityId: string, payload: unknown, nowIso: string): S
     externalCallId: asString(input, ["externalCallId", "external_call_id"], id) ?? id,
     sipCallId: asString(input, ["sipCallId", "sip_call_id"], null),
     callerNumber: asString(input, ["callerNumber", "caller_number"], null),
-    direction: direction === "outbound" ? "outbound" : "inbound",
+    direction,
     calleeNumber,
     callerCategory: asString(input, ["callerCategory", "caller_category"], "unknown") ?? "unknown",
     actionCode: asString(input, ["actionCode", "action_code"], "IV") ?? "IV",

--- a/virtual-voicebot-frontend/lib/db/sync.ts
+++ b/virtual-voicebot-frontend/lib/db/sync.ts
@@ -197,13 +197,18 @@ function normalizeCallLog(entityId: string, payload: unknown, nowIso: string): S
   const input = isRecord(payload) ? payload : {}
   const id = asString(input, ["id"], entityId) ?? entityId
   const direction = asString(input, ["direction"], "inbound")
+  const calleeNumberRaw = asString(input, ["calleeNumber", "callee_number"], null)
+  const calleeNumber =
+    typeof calleeNumberRaw === "string" && calleeNumberRaw.trim().length === 0
+      ? null
+      : calleeNumberRaw
   return {
     id,
     externalCallId: asString(input, ["externalCallId", "external_call_id"], id) ?? id,
     sipCallId: asString(input, ["sipCallId", "sip_call_id"], null),
     callerNumber: asString(input, ["callerNumber", "caller_number"], null),
     direction: direction === "outbound" ? "outbound" : "inbound",
-    calleeNumber: asString(input, ["calleeNumber", "callee_number"], null),
+    calleeNumber,
     callerCategory: asString(input, ["callerCategory", "caller_category"], "unknown") ?? "unknown",
     actionCode: asString(input, ["actionCode", "action_code"], "IV") ?? "IV",
     ivrFlowId: asString(input, ["ivrFlowId", "ivr_flow_id"], null),

--- a/virtual-voicebot-frontend/lib/db/sync.ts
+++ b/virtual-voicebot-frontend/lib/db/sync.ts
@@ -20,6 +20,8 @@ export interface StoredCallLog {
   externalCallId: string
   sipCallId: string | null
   callerNumber: string | null
+  direction: string
+  calleeNumber: string | null
   callerCategory: string
   actionCode: string
   ivrFlowId: string | null
@@ -194,11 +196,14 @@ function asIsoDate(
 function normalizeCallLog(entityId: string, payload: unknown, nowIso: string): StoredCallLog {
   const input = isRecord(payload) ? payload : {}
   const id = asString(input, ["id"], entityId) ?? entityId
+  const direction = asString(input, ["direction"], "inbound")
   return {
     id,
     externalCallId: asString(input, ["externalCallId", "external_call_id"], id) ?? id,
     sipCallId: asString(input, ["sipCallId", "sip_call_id"], null),
     callerNumber: asString(input, ["callerNumber", "caller_number"], null),
+    direction: direction === "outbound" ? "outbound" : "inbound",
+    calleeNumber: asString(input, ["calleeNumber", "callee_number"], null),
     callerCategory: asString(input, ["callerCategory", "caller_category"], "unknown") ?? "unknown",
     actionCode: asString(input, ["actionCode", "action_code"], "IV") ?? "IV",
     ivrFlowId: asString(input, ["ivrFlowId", "ivr_flow_id"], null),

--- a/virtual-voicebot-frontend/lib/mock-data.ts
+++ b/virtual-voicebot-frontend/lib/mock-data.ts
@@ -24,6 +24,7 @@ export type CallRecord = {
   from: string
   fromName: string
   to: string
+  calleeNumber: string | null
   startedAt: string
   endedAt: string | null
   status: CallRecordStatus
@@ -51,6 +52,8 @@ export const mockCalls: Call[] = [
     id: "1",
     externalCallId: "c_001",
     callerNumber: "+81-90-1234-5678",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "registered",
     actionCode: "VR",
     status: "ended",
@@ -70,6 +73,8 @@ export const mockCalls: Call[] = [
     id: "2",
     externalCallId: "c_002",
     callerNumber: "+81-80-2222-1111",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "registered",
     actionCode: "IV",
     status: "ended",
@@ -89,6 +94,8 @@ export const mockCalls: Call[] = [
     id: "3",
     externalCallId: "c_003",
     callerNumber: "+81-50-8888-1111",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "unknown",
     actionCode: "IV",
     status: "in_call",
@@ -108,6 +115,8 @@ export const mockCalls: Call[] = [
     id: "4",
     externalCallId: "c_004",
     callerNumber: "+81-70-3333-2222",
+    direction: "outbound",
+    calleeNumber: "+81-90-2222-3333",
     callerCategory: "registered",
     actionCode: "VR",
     status: "ended",
@@ -127,6 +136,8 @@ export const mockCalls: Call[] = [
     id: "5",
     externalCallId: "c_005",
     callerNumber: "+81-90-9999-0001",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "spam",
     actionCode: "RJ",
     status: "error",
@@ -146,6 +157,8 @@ export const mockCalls: Call[] = [
     id: "6",
     externalCallId: "c_006",
     callerNumber: "+81-3-4444-5555",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "registered",
     actionCode: "VR",
     status: "ended",
@@ -165,6 +178,8 @@ export const mockCalls: Call[] = [
     id: "7",
     externalCallId: "c_007",
     callerNumber: "+81-90-5555-1212",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "registered",
     actionCode: "VR",
     status: "ended",
@@ -184,6 +199,8 @@ export const mockCalls: Call[] = [
     id: "8",
     externalCallId: "c_008",
     callerNumber: "+81-90-7777-8888",
+    direction: "outbound",
+    calleeNumber: "+81-70-1111-2222",
     callerCategory: "registered",
     actionCode: "VR",
     status: "ended",
@@ -203,6 +220,8 @@ export const mockCalls: Call[] = [
     id: "9",
     externalCallId: "c_009",
     callerNumber: "+81-80-2323-4545",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "registered",
     actionCode: "IV",
     status: "ended",
@@ -222,6 +241,8 @@ export const mockCalls: Call[] = [
     id: "10",
     externalCallId: "c_010",
     callerNumber: "+81-90-1111-2222",
+    direction: "inbound",
+    calleeNumber: null,
     callerCategory: "registered",
     actionCode: "VR",
     status: "ringing",
@@ -314,13 +335,16 @@ export const mockCallPresentationById: Record<string, CallPresentation> = {
 
 export const mockCallRecords: CallRecord[] = mockCalls.map((call) => {
   const view = mockCallPresentationById[call.id]
+  const direction = toCallRecordDirection(call)
+  const isOutbound = direction === "outbound"
   return {
     id: call.id,
     callId: call.externalCallId,
     actionCode: call.actionCode,
     from: call.callerNumber ?? "非通知",
-    fromName: view?.fromName ?? categoryLabel(call.callerCategory),
-    to: view?.to ?? "未設定",
+    fromName: isOutbound ? "-" : (view?.fromName ?? categoryLabel(call.callerCategory)),
+    to: isOutbound ? (call.calleeNumber ?? "-") : (view?.to ?? "未設定"),
+    calleeNumber: call.calleeNumber ?? null,
     startedAt: call.startedAt,
     endedAt: call.endedAt,
     status: toCallRecordStatus(call.status),
@@ -332,7 +356,7 @@ export const mockCallRecords: CallRecord[] = mockCalls.map((call) => {
     displayDurationSec: resolveDisplayDuration(call),
     summary: view?.summary ?? "",
     recordingUrl: view?.recordingUrl ?? null,
-    direction: view?.direction ?? "inbound",
+    direction,
   }
 })
 
@@ -346,6 +370,13 @@ function toCallRecordStatus(status: CallStatus): CallRecordStatus {
     default:
       return "ended"
   }
+}
+
+function toCallRecordDirection(call: Call): CallDirection {
+  if (call.status === "error" || call.endReason === "rejected") {
+    return "missed"
+  }
+  return call.direction
 }
 
 function categoryLabel(category: CallerCategory): string {

--- a/virtual-voicebot-frontend/lib/types.ts
+++ b/virtual-voicebot-frontend/lib/types.ts
@@ -27,6 +27,8 @@ export type FinalAction =
 
 export type TransferStatus = "no_transfer" | "none" | "trying" | "answered" | "failed"
 
+export type CallDirection = "inbound" | "outbound"
+
 export type IvrEventType =
   | "node_enter"
   | "dtmf_input"
@@ -57,6 +59,8 @@ export interface Call {
   id: string
   externalCallId: string
   callerNumber: string | null
+  direction: CallDirection
+  calleeNumber: string | null
   callerCategory: CallerCategory
   actionCode: ActionCode
   status: CallStatus


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 発信通話の履歴表示を改善し、発信先番号を正しく表示。発信通話で不適用な項目（応答記録、IVR詳細等）は「-」で表示します。
  * 発信転送を考慮した応答判定を追加し、新しい表示状態「応答なし」を導入しました。
  * 検索に発信先番号を含め、検索精度を向上しました。
* **ドキュメント**
  * 発信履歴表示の要件、受入基準、移行メモとテストケースを追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->